### PR TITLE
Create test for multiple worlds having different cell representations

### DIFF
--- a/sensorimotor/tests/integration/sensorimotor_temporal_memory_test.py
+++ b/sensorimotor/tests/integration/sensorimotor_temporal_memory_test.py
@@ -165,7 +165,6 @@ class SensorimotorTemporalMemoryTest(AbstractSensorimotorTest):
     self.assertTrue(0 < stats.predictedInactiveColumns.average < 10)
 
 
-  @unittest.skip("TODO: Determine why this test fails")
   def testMultipleWorldsSharedPatternsNoSharedSubsequences(self):
     """
     Test Sensorimotor Temporal Memory learning in multiple separate worlds.
@@ -176,7 +175,7 @@ class SensorimotorTemporalMemoryTest(AbstractSensorimotorTest):
     """
     self._init()
 
-    universe = OneDUniverse(debugMotor=True,
+    universe = OneDUniverse(debugSensor=True, debugMotor=True,
                             nSensor=100, wSensor=10,
                             nMotor=70, wMotor=10)
 
@@ -184,7 +183,8 @@ class SensorimotorTemporalMemoryTest(AbstractSensorimotorTest):
     patterns = range(4)
     for _ in xrange(2):
       world = OneDWorld(universe, patterns, 2)
-      agent = RandomOneDAgent(world, possibleMotorValues=set(xrange(-3, 4)))
+      agent = RandomOneDAgent(world, possibleMotorValues=set([-3, -2, -1,
+                                                              1,  2, 3]))
       agents.append(agent)
       patterns = list(patterns)  # copy
       patterns.reverse()


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic.research/issues/32.

@subutai I realized what the problem was with this test (ABCD / DCBA), and why it was saying each predicted cell shows up in more than one sequence. Since it was allowing movement of 0 (no movement), each sequence would share the cells representing transitions from a pattern to itself. Once I disallowed movement of 0 (and set `debugSensor=True`, so no columns were shared between patterns), the test reported that each predicted active cell showed up in exactly 1 sequence. Hooray!
