### PR TITLE
ColumnPooler: Call setRandomZerosOnOuter with int32, not uint32

### DIFF
--- a/htmresearch/algorithms/column_pooler.py
+++ b/htmresearch/algorithms/column_pooler.py
@@ -540,7 +540,9 @@ class ColumnPooler(object):
     else:
       existingSynapseCounts = permanences.nNonZerosPerRowOnCols(
         activeCells, activeInput)
-      maxNewByCell = sampleSize - existingSynapseCounts
+
+      maxNewByCell = numpy.empty(len(activeCells), dtype="int32")
+      numpy.subtract(sampleSize, existingSynapseCounts, out=maxNewByCell)
 
       permanences.setRandomZerosOnOuter(
         activeCells, growthCandidateInput, maxNewByCell, initialPermanence, rng)


### PR DESCRIPTION
This avoids an unnecessary array copy.