### PR TITLE
Run capacity experiment with different accuracy metrics

### DIFF
--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -308,7 +308,7 @@ def testOnSingleRandomSDR(objects, exp, numRepeats=100, repeatID=0):
 
 
 def plotResults(result, ax=None, xaxis="numObjects",
-                filename=None, marker='-bo', confuseThresh=20):
+                filename=None, marker='-bo', confuseThresh=20, showErrBar=1):
 
   if ax is None:
     fig, ax = plt.subplots(2, 2)
@@ -344,10 +344,10 @@ def plotResults(result, ax=None, xaxis="numObjects",
   for rpt in range(1, numRpts):
     d = resultsRpts.get_group(rpt)
     d = d.groupby(['numObjects'])
-    accuracyRpt = np.zeros((len(x),))
-    numberOfConnectedProximalSynapsesRpt = np.zeros((len(x),))
-    l2ActivationSizeRpt = np.zeros((len(x),))
-    confusionRpt = np.zeros((len(x),))
+    accuracyRpt = np.zeros((1, len(x)))
+    numberOfConnectedProximalSynapsesRpt = np.zeros((1, len(x)))
+    l2ActivationSizeRpt = np.zeros((1, len(x)))
+    confusionRpt = np.zeros((1, len(x)))
 
     for j in range(len(x)):
       accuracyRpt[0,j] = np.sum(np.logical_and(
@@ -366,24 +366,28 @@ def plotResults(result, ax=None, xaxis="numObjects",
     numberOfConnectedProximalSynapses = np.vstack((
       numberOfConnectedProximalSynapses, numberOfConnectedProximalSynapsesRpt))
 
-  ax[0, 0].errorbar(x, np.mean(accuracy, 0), yerr=np.std(accuracy, 0),
+  if showErrBar==0:
+    s = 0
+  else:
+    s = 1
+  ax[0, 0].errorbar(x, np.mean(accuracy, 0), yerr=np.std(accuracy, 0)*s,
                     color=marker)
   ax[0, 0].set_ylabel("Accuracy")
   ax[0, 0].set_xlabel(xlabel)
   ax[0, 0].set_ylim([0.1, 1.05])
 
   ax[0, 1].errorbar(x, np.mean(numberOfConnectedProximalSynapses, 0),
-                    yerr=np.std(numberOfConnectedProximalSynapses, 0), color=marker)
+                    yerr=np.std(numberOfConnectedProximalSynapses, 0)*s, color=marker)
   ax[0, 1].set_ylabel("# connected proximal synapses")
   ax[0, 1].set_xlabel("# Pts / Obj")
   ax[0, 1].set_xlabel(xlabel)
 
-  ax[1, 0].errorbar(x, np.mean(l2ActivationSize, 0), yerr=np.std(l2ActivationSize, 0), color=marker)
+  ax[1, 0].errorbar(x, np.mean(l2ActivationSize, 0), yerr=np.std(l2ActivationSize, 0)*s, color=marker)
   ax[1, 0].set_ylabel("l2ActivationSize")
   # ax[1, 0].set_ylim([0, 41])
   ax[1, 0].set_xlabel(xlabel)
 
-  ax[1, 1].errorbar(x, np.mean(confusion, 0), yerr=np.std(confusion, 0), color=marker)
+  ax[1, 1].errorbar(x, np.mean(confusion, 0), yerr=np.std(confusion, 0)*s, color=marker)
   ax[1, 1].set_ylabel("OverlapFalseObject")
   ax[1, 1].set_ylim([0, 41])
   ax[1, 1].set_xlabel(xlabel)
@@ -715,7 +719,7 @@ def runExperiment3(numCorticalColumns=DEFAULT_NUM_CORTICAL_COLUMNS,
   """
 
   numPointsPerObject = 10
-  numRpts = 5
+  numRpts = 10
   l4Params = getL4Params()
   l2Params = getL2Params()
 
@@ -810,7 +814,7 @@ def runExperiment4(resultDirName=DEFAULT_RESULT_DIR_NAME,
   """
 
   numPointsPerObject = 10
-  numRpts = 1
+  numRpts = 3
 
   l4Params = getL4Params()
   l2Params = getL2Params()
@@ -903,7 +907,7 @@ def runExperiment5(resultDirName=DEFAULT_RESULT_DIR_NAME,
   """
 
   numPointsPerObject = 10
-  numRpts = 5
+  numRpts = 3
   numInputBits = 20
   externalInputSize = 2400
   numL4MiniColumns = 256
@@ -1100,24 +1104,24 @@ def runExperiment6(resultDirName=DEFAULT_RESULT_DIR_NAME,
 
 def runExperiments(resultDirName, plotDirName, cpuCount):
 
-  # Varying number of pts per objects, two objects
-  runExperiment1(numCorticalColumns=1,
-                 resultDirName=resultDirName,
-                 plotDirName=plotDirName,
-                 cpuCount=cpuCount)
+  # # Varying number of pts per objects, two objects
+  # runExperiment1(numCorticalColumns=1,
+  #                resultDirName=resultDirName,
+  #                plotDirName=plotDirName,
+  #                cpuCount=cpuCount)
+  #
+  # # 10 pts per object, varying number of objects
+  # runExperiment2(numCorticalColumns=1,
+  #                resultDirName=resultDirName,
+  #                plotDirName=plotDirName,
+  #                cpuCount=cpuCount)
 
-  # 10 pts per object, varying number of objects
-  runExperiment2(numCorticalColumns=1,
-                 resultDirName=resultDirName,
-                 plotDirName=plotDirName,
-                 cpuCount=cpuCount)
 
-
-  # 10 pts per object, varying number of objects, varying L4 size
-  runExperiment3(numCorticalColumns=1,
-                 resultDirName=resultDirName,
-                 plotDirName=plotDirName,
-                 cpuCount=cpuCount)
+  # # 10 pts per object, varying number of objects, varying L4 size
+  # runExperiment3(numCorticalColumns=1,
+  #                resultDirName=resultDirName,
+  #                plotDirName=plotDirName,
+  #                cpuCount=cpuCount)
 
 
   # 10 pts per object, varying number of objects and number of columns
@@ -1130,10 +1134,10 @@ def runExperiments(resultDirName, plotDirName, cpuCount):
                  plotDirName=plotDirName,
                  cpuCount=cpuCount)
 
-  # 10 pts per object, varying sparsity of L2
-  runExperiment6(resultDirName=resultDirName,
-                 plotDirName=plotDirName,
-                 cpuCount=cpuCount)
+  # # 10 pts per object, varying sparsity of L2
+  # runExperiment6(resultDirName=resultDirName,
+  #                plotDirName=plotDirName,
+  #                cpuCount=cpuCount)
 
 
 

--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -486,20 +486,7 @@ def runCapacityTestVaryingObjectSize(
              0)
             for numPointsPerObject in np.arange(10, 160, 20)]
 
-  # for param in params:
-  #   print param
-  #   testResult = invokeRunCapacityTest(param)
-  #   print testResult
-  #   result = (
-  #     pd.concat([result, pd.DataFrame.from_dict([testResult])])
-  #     if result is not None else
-  #     pd.DataFrame.from_dict([testResult])
-  #   )
-  #
-  # print result
   for testResult in pool.map(invokeRunCapacityTest, params):
-    print testResult
-
     result = (
       pd.concat([result, pd.DataFrame.from_dict([testResult])])
       if result is not None else
@@ -557,8 +544,6 @@ def runCapacityTestVaryingObjectNum(numPointsPerObject=10,
                  rpt))
 
   for testResult in pool.map(invokeRunCapacityTest, params):
-    print testResult
-
     result = (
       pd.concat([result, testResult])
       if result is not None else testResult

--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -579,7 +579,7 @@ def runCapacityTestVaryingObjectNum(numPointsPerObject=10,
   cpuCount = cpuCount or multiprocessing.cpu_count()
   pool = multiprocessing.Pool(cpuCount, maxtasksperchild=1)
 
-  numObjectsList = np.arange(50, 800, 200)
+  numObjectsList = np.arange(50, 800, 50)
   params = []
   for rpt in range(numRpts):
     for numObjects in numObjectsList:

--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -325,17 +325,17 @@ def plotResults(result, ax=None, xaxis="numObjects",
   x = np.unique(x)
   d = resultsRpts.get_group(0)
   d = d.groupby(['numObjects'])
-  accuracy = np.zeros((len(x),))
-  numberOfConnectedProximalSynapses = np.zeros((len(x),))
-  l2ActivationSize = np.zeros((len(x),))
-  confusion = np.zeros((len(x),))
+  accuracy = np.zeros((1, len(x),))
+  numberOfConnectedProximalSynapses = np.zeros((1, len(x),))
+  l2ActivationSize = np.zeros((1, len(x),))
+  confusion = np.zeros((1, len(x),))
   for j in range(len(x)):
-    accuracy[j] = np.sum(np.logical_and(d.get_group(x[j]).accuracy == 1,
+    accuracy[0,j] = np.sum(np.logical_and(d.get_group(x[j]).accuracy == 1,
                                         d.get_group(x[j]).confusion < confuseThresh)) / \
                   float(len(d.get_group(x[j]).accuracy))
-    l2ActivationSize[j] = np.mean(d.get_group(x[j]).l2ActivationSize)
-    confusion[j] = np.mean(d.get_group(x[j]).confusion)
-    numberOfConnectedProximalSynapses[j] = np.mean(
+    l2ActivationSize[0,j] = np.mean(d.get_group(x[j]).l2ActivationSize)
+    confusion[0,j] = np.mean(d.get_group(x[j]).confusion)
+    numberOfConnectedProximalSynapses[0,j] = np.mean(
       d.get_group(x[j]).numberOfConnectedProximalSynapses)
 
   if ax is None:
@@ -350,14 +350,14 @@ def plotResults(result, ax=None, xaxis="numObjects",
     confusionRpt = np.zeros((len(x),))
 
     for j in range(len(x)):
-      accuracyRpt[j] = np.sum(np.logical_and(
+      accuracyRpt[0,j] = np.sum(np.logical_and(
         d.get_group(x[j]).accuracy == 1,
         d.get_group(x[j]).confusion < confuseThresh)) / \
                        float(len(d.get_group(x[j]).accuracy))
 
-      l2ActivationSizeRpt[j] = np.mean(d.get_group(x[j]).l2ActivationSize)
-      confusionRpt[j] = np.mean(d.get_group(x[j]).confusion)
-      numberOfConnectedProximalSynapsesRpt[j] = np.mean(
+      l2ActivationSizeRpt[0,j] = np.mean(d.get_group(x[j]).l2ActivationSize)
+      confusionRpt[0,j] = np.mean(d.get_group(x[j]).confusion)
+      numberOfConnectedProximalSynapsesRpt[0,j] = np.mean(
         d.get_group(x[j]).numberOfConnectedProximalSynapses)
 
     accuracy = np.vstack((accuracy, accuracyRpt))

--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -1099,41 +1099,41 @@ def runExperiment6(resultDirName=DEFAULT_RESULT_DIR_NAME,
 
 
 def runExperiments(resultDirName, plotDirName, cpuCount):
-  #
-  # # Varying number of pts per objects, two objects
-  # runExperiment1(numCorticalColumns=1,
-  #                resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
-  #
-  # # 10 pts per object, varying number of objects
-  # runExperiment2(numCorticalColumns=1,
-  #                resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
-  #
-  #
-  # # 10 pts per object, varying number of objects, varying L4 size
-  # runExperiment3(numCorticalColumns=1,
-  #                resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
-  #
+
+  # Varying number of pts per objects, two objects
+  runExperiment1(numCorticalColumns=1,
+                 resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
+
+  # 10 pts per object, varying number of objects
+  runExperiment2(numCorticalColumns=1,
+                 resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
+
+
+  # 10 pts per object, varying number of objects, varying L4 size
+  runExperiment3(numCorticalColumns=1,
+                 resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
+
 
   # 10 pts per object, varying number of objects and number of columns
   runExperiment4(resultDirName=resultDirName,
                  plotDirName=plotDirName,
                  cpuCount=cpuCount)
 
-  # # 10 pts per object, varying number of L2 cells
-  # runExperiment5(resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
+  # 10 pts per object, varying number of L2 cells
+  runExperiment5(resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
 
-  # # 10 pts per object, varying sparsity of L2
-  # runExperiment6(resultDirName=resultDirName,
-  #                plotDirName=plotDirName,
-  #                cpuCount=cpuCount)
+  # 10 pts per object, varying sparsity of L2
+  runExperiment6(resultDirName=resultDirName,
+                 plotDirName=plotDirName,
+                 cpuCount=cpuCount)
 
 
 

--- a/projects/l2_pooling/plot_capacity_result.py
+++ b/projects/l2_pooling/plot_capacity_result.py
@@ -1,0 +1,181 @@
+import os
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+
+from capacity_test import _prepareResultsDir, plotResults
+from capacity_test import DEFAULT_RESULT_DIR_NAME, DEFAULT_PLOT_DIR_NAME
+
+plt.ion()
+
+if __name__ == "__main__":
+  numCorticalColumns = 1
+  confusionThreshold = 35
+
+  l4ColumnCountList = [256, 256, 512]
+  numInputBitsList = [12, 5, 10]
+
+  resultDirName=DEFAULT_RESULT_DIR_NAME
+  plotDirName=DEFAULT_PLOT_DIR_NAME
+
+  DEFAULT_RESULT_DIR_NAME = "results"
+  DEFAULT_PLOT_DIR_NAME = "plots"
+  DEFAULT_COLORS = ("b", "r", "c", "g", 'm')
+
+  # Plot capacity vs L4 size
+  expParams = []
+  expParams.append(
+    {'l4Column': 150, 'externalInputSize': 2400, 'w': 20, 'sample': 6,
+     'thresh': 3})
+  expParams.append(
+    {'l4Column': 256, 'externalInputSize': 2400, 'w': 20, 'sample': 6,
+     'thresh': 3})
+  expParams.append(
+    {'l4Column': 512, 'externalInputSize': 2400, 'w': 20, 'sample': 6,
+     'thresh': 3})
+
+  # plot result
+  ploti = 0
+  fig, ax = plt.subplots(2, 2)
+  st = fig.suptitle(
+    "Varying number of objects ({} cortical column{})"
+      .format(numCorticalColumns, "s" if numCorticalColumns > 1 else ""
+              ), fontsize="x-large"
+  )
+
+  for axi in (0, 1):
+    for axj in (0, 1):
+      ax[axi][axj].xaxis.set_major_locator(ticker.MultipleLocator(100))
+
+  legendEntries = []
+  for expParam in expParams:
+    expname = "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}_l4column_{}".format(
+      expParam['sample'], expParam['thresh'], expParam["l4Column"])
+
+    resultFileName = _prepareResultsDir("{}.csv".format(expname),
+                                        resultDirName=resultDirName
+                                        )
+
+    result = pd.read_csv(resultFileName)
+
+    plotResults(result, ax, "numObjects", None, DEFAULT_COLORS[ploti], confusionThreshold, 0)
+    ploti += 1
+    legendEntries.append("L4 mcs {} w {} s {} thresh {}".format(
+      expParam["l4Column"], expParam['w'], expParam['sample'],
+      expParam['thresh']))
+  ax[0, 0].legend(legendEntries, loc=4, fontsize=8)
+  fig.tight_layout()
+
+  # shift subplots down:
+  st.set_y(0.95)
+  fig.subplots_adjust(top=0.85)
+
+  plt.savefig(
+    os.path.join(
+      plotDirName,
+      "capacity_varying_object_num_l4size_summary.pdf"
+    )
+  )
+
+  # Plot capacity vs L2 size
+
+  expParams = []
+  expParams.append(
+    {'L2cellCount': 2048, 'L2activeBits': 40, 'w': 10, 'sample': 6, 'thresh': 3,
+     'l2Column': 1})
+  expParams.append(
+    {'L2cellCount': 4096, 'L2activeBits': 40, 'w': 10, 'sample': 6, 'thresh': 3,
+     'l2Column': 1})
+  expParams.append(
+    {'L2cellCount': 8192, 'L2activeBits': 40, 'w': 10, 'sample': 6, 'thresh': 3,
+     'l2Column': 1})
+
+  # plot result
+  ploti = 0
+  fig, ax = plt.subplots(2, 2)
+  st = fig.suptitle("Varying number of objects", fontsize="x-large")
+
+  for axi in (0, 1):
+    for axj in (0, 1):
+      ax[axi][axj].xaxis.set_major_locator(ticker.MultipleLocator(100))
+
+  legendEntries = []
+  for expParam in expParams:
+    expName = "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}_l2Cells_{}_l2column_{}".format(
+      expParam['sample'], expParam['thresh'], expParam["L2cellCount"],
+      expParam['l2Column'])
+
+    resultFileName = _prepareResultsDir("{}.csv".format(expName),
+                                        resultDirName=resultDirName
+                                        )
+
+    result = pd.read_csv(resultFileName)
+
+    plotResults(result, ax, "numObjects", None, DEFAULT_COLORS[ploti], confusionThreshold, 0)
+    ploti += 1
+    legendEntries.append("L2 cells {}/{} #cc {} ".format(
+      expParam['L2activeBits'], expParam['L2cellCount'], expParam['l2Column']))
+  ax[0, 0].legend(legendEntries, loc=3, fontsize=8)
+  fig.tight_layout()
+
+  # shift subplots down:
+  st.set_y(0.95)
+  fig.subplots_adjust(top=0.85)
+
+  plt.savefig(
+    os.path.join(
+      plotDirName,
+      "capacity_vs_L2size.pdf"
+    )
+  )
+
+
+  # Plot capacity vs number of cortical columns
+
+  expParams = []
+  expParams.append(
+    {'l4Column': 150, 'externalInputSize': 2400, 'w': 10, 'sample': 6,
+     'thresh': 3, 'l2Column': 1})
+  expParams.append(
+    {'l4Column': 150, 'externalInputSize': 2400, 'w': 10, 'sample': 6,
+     'thresh': 3, 'l2Column': 2})
+  expParams.append(
+    {'l4Column': 150, 'externalInputSize': 2400, 'w': 10, 'sample': 6,
+     'thresh': 3, 'l2Column': 3})
+
+  # plot result
+  ploti = 0
+  fig, ax = plt.subplots(2, 2)
+  st = fig.suptitle("Varying number of columns", fontsize="x-large")
+
+  for axi in (0, 1):
+    for axj in (0, 1):
+      ax[axi][axj].xaxis.set_major_locator(ticker.MultipleLocator(100))
+
+  legendEntries = []
+  for expParam in expParams:
+    expName = "multiple_column_capacity_varying_object_num_synapses_{}_thresh_{}_l4column_{}_l2column_{}".format(
+      expParam['sample'], expParam['thresh'], expParam["l4Column"],
+      expParam['l2Column'])
+
+    resultFileName = _prepareResultsDir("{}.csv".format(expName),
+                                        resultDirName=resultDirName
+                                        )
+
+    result = pd.read_csv(resultFileName)
+
+    plotResults(result, ax, "numObjects", None, DEFAULT_COLORS[ploti], confusionThreshold, 0)
+    ploti += 1
+    legendEntries.append("L4 mcs {} #cc {} ".format(
+      expParam['l4Column'], expParam['l2Column']))
+
+  # shift subplots down:
+  st.set_y(0.95)
+  fig.subplots_adjust(top=0.85)
+
+  plt.savefig(
+    os.path.join(
+      plotDirName,
+      "capacity_vs_num_columns.pdf"
+    )
+  )


### PR DESCRIPTION
@subutai  Please review.

Summary

* Save experiment log for individual test trials (previously we only save the summary statistics for 100 trials)

* Using more stringent accuracy metrics. A test trial will be labeled as successful if 1. overlap with the correct object is the highest (no ties) 2. overlap with the non-target objects needs to be smaller than a predefined threshold. The figures below show the capacity result when this threshold is set to be 35，20, 10 and 5. The number of L2 sdr size is set to be 40.

Threshold = 35
![image](https://cloud.githubusercontent.com/assets/5067931/25921821/c67df38c-358b-11e7-8bdd-027eff1bf118.png)

Threshold = 20
![image](https://cloud.githubusercontent.com/assets/5067931/25921666/21acb05a-358b-11e7-8dfd-587fa72e096a.png)

Threshold = 10
![image](https://cloud.githubusercontent.com/assets/5067931/25921700/453ca750-358b-11e7-86c4-7d0f6d796ee1.png)

Threshold = 5
![image](https://cloud.githubusercontent.com/assets/5067931/25921679/307af196-358b-11e7-83e5-d67d44735564.png)

