### PR TITLE
Faster capacity test: Use SparseMatrix to calculate object overlaps

### DIFF
--- a/projects/l2_pooling/capacity_test.py
+++ b/projects/l2_pooling/capacity_test.py
@@ -242,12 +242,8 @@ def testNetworkWithOneObject(objects, exp, testObject, numTestPoints):
     numL2ActiveCells[step] /= exp.numColumns
     numL4ActiveCells[step] /= exp.numColumns
 
-    for obj in xrange(numObjects):
-      overlap[step, obj] = np.mean([
-        len(exp.objectL2Representations[obj][colIdx] &
-            exp.getL2Representations()[colIdx])
-        for colIdx in xrange(exp.numColumns)]
-      )
+    overlapByColumn = exp.getCurrentObjectOverlaps()
+    overlap[step] = np.mean(overlapByColumn, axis=0)
 
     # columnPooler = exp.L2Columns[0]._pooler
     # tm = exp.L4Columns[0]._tm
@@ -436,7 +432,8 @@ def runCapacityTest(numObjects,
                        inputSize=l4ColumnCount,
                        externalInputSize=externalInputSize,
                        numLearningPoints=3,
-                       numCorticalColumns=numCorticalColumns)
+                       numCorticalColumns=numCorticalColumns,
+                       objectNamesAreIndices=True)
 
   if objectParams["uniquePairs"]:
     pairs = createRandomObjects(


### PR DESCRIPTION
@ywcui1990 A lot of time was spent computing overlaps between L2 and every object. This change eliminates almost all of that overhead.

If I run a small capacity experiment, here are the times:

**Before**: 200 seconds
**After**: 114 seconds

So it now takes ~57% of the time that it previously took.