### PR TITLE
Add a "Location Module" object inference experiment

### DIFF
--- a/htmresearch/algorithms/superficial_location_module.py
+++ b/htmresearch/algorithms/superficial_location_module.py
@@ -1,0 +1,360 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Emulates a grid cell module"""
+
+import math
+
+import numpy as np
+
+from htmresearch.support import numpy_helpers as np2
+from nupic.bindings.math import SparseMatrixConnections, Random
+
+
+
+class SuperficialLocationModule2D(object):
+  """
+  A model of a location module. It's similar to a grid cell module, but it uses
+  squares rather than triangles.
+
+  The cells are arranged into a m*n rectangle which is tiled onto 2D space.
+  Each cell represents a small rectangle in each tile.
+
+  +------+------+------++------+------+------+
+  | Cell | Cell | Cell || Cell | Cell | Cell |
+  |  #1  |  #2  |  #3  ||  #1  |  #2  |  #3  |
+  |      |      |      ||      |      |      |
+  +--------------------++--------------------+
+  | Cell | Cell | Cell || Cell | Cell | Cell |
+  |  #4  |  #5  |  #6  ||  #4  |  #5  |  #6  |
+  |      |      |      ||      |      |      |
+  +--------------------++--------------------+
+  | Cell | Cell | Cell || Cell | Cell | Cell |
+  |  #7  |  #8  |  #9  ||  #7  |  #8  |  #9  |
+  |      |      |      ||      |      |      |
+  +------+------+------++------+------+------+
+
+  We assume that path integration works *somehow*. This model receives a "delta
+  location" vector, and it shifts the active cells accordingly. The model stores
+  intermediate coordinates of active cells. Whenever sensory cues activate a
+  cell, the model adds this cell to the list of coordinates being shifted.
+  Whenever sensory cues cause a cell to become inactive, that cell is removed
+  from the list of coordinates.
+
+  (This model doesn't attempt to propose how "path integration" works. It
+  attempts to show how locations are anchored to sensory cues.)
+
+  When orientation is set to 0 degrees, the deltaLocation is a [di, dj],
+  moving di cells "down" and dj cells "right".
+
+  When orientation is set to 90 degrees, the deltaLocation is essentially a
+  [dx, dy], applied in typical x,y coordinates with the origin on the bottom
+  left.
+
+  Usage:
+
+  Adjust the location in response to motor input:
+    lm.shift([di, dj])
+
+  Adjust the location in response to sensory input:
+    lm.anchor(anchorInput)
+
+  Learn an anchor input for the current location:
+    lm.learn(anchorInput)
+
+  The "anchor input" is typically a feature-location pair SDR.
+
+  During inference, you'll typically call:
+    lm.shift(...)
+    # Consume lm.getActiveCells()
+    # ...
+    lm.anchor(...)
+
+  During learning, you'll do the same, but you'll call lm.learn() instead of
+  lm.anchor().
+  """
+
+
+  def __init__(self,
+               cellDimensions,
+               moduleMapDimensions,
+               orientation,
+               anchorInputSize,
+               pointOffsets=(0.5,),
+               activationThreshold=10,
+               initialPermanence=0.21,
+               connectedPermanence=0.50,
+               learningThreshold=10,
+               sampleSize=20,
+               permanenceIncrement=0.1,
+               permanenceDecrement=0.0,
+               maxSynapsesPerSegment=-1,
+               seed=42):
+    """
+    @param cellDimensions (tuple(int, int))
+    Determines the number of cells. Determines how space is divided between the
+    cells.
+
+    @param moduleMapDimensions (tuple(float, float))
+    Determines the amount of world space covered by all of the cells combined.
+    In grid cell terminology, this is equivalent to the "scale" of a module.
+    A module with a scale of "5cm" would have moduleMapDimensions=(5.0, 5.0).
+
+    @param orientation (float)
+    The rotation of this map, measured in radians.
+
+    @param anchorInputSize (int)
+    The number of input bits in the anchor input.
+
+    @param pointOffsets (list of floats)
+    These must each be between 0.0 and 1.0. Every time a cell is activated by
+    anchor input, this class adds a "point" which is shifted in subsequent
+    motions. By default, this point is placed at the center of the cell. This
+    parameter allows you to control where the point is placed and whether multiple
+    are placed. For example, With value [0.2, 0.8], it will place 4 points:
+    [0.2, 0.2], [0.2, 0.8], [0.8, 0.2], [0.8, 0.8]
+    """
+
+    self.cellDimensions = np.asarray(cellDimensions, dtype="int")
+    self.moduleMapDimensions = np.asarray(moduleMapDimensions, dtype="float")
+    self.cellFieldsPerUnitDistance = self.cellDimensions / self.moduleMapDimensions
+
+    self.orientation = orientation
+    self.rotationMatrix = np.array(
+      [[math.cos(orientation), -math.sin(orientation)],
+       [math.sin(orientation), math.cos(orientation)]])
+
+    self.pointOffsets = pointOffsets
+
+    # These coordinates are in units of "cell fields".
+    self.activePoints = np.empty((0,2), dtype="float")
+    self.cellsForActivePoints = np.empty(0, dtype="int")
+
+    self.activeCells = np.empty(0, dtype="int")
+    self.activeSegments = np.empty(0, dtype="uint32")
+
+    self.connections = SparseMatrixConnections(np.prod(cellDimensions),
+                                               anchorInputSize)
+
+    self.initialPermanence = initialPermanence
+    self.connectedPermanence = connectedPermanence
+    self.learningThreshold = learningThreshold
+    self.sampleSize = sampleSize
+    self.permanenceIncrement = permanenceIncrement
+    self.permanenceDecrement = permanenceDecrement
+    self.activationThreshold = activationThreshold
+    self.maxSynapsesPerSegment = maxSynapsesPerSegment
+
+    self.rng = Random(seed)
+
+
+  def reset(self):
+    """
+    Clear the active cells.
+    """
+    self.activePoints = np.empty((0,2), dtype="float")
+    self.cellsForActivePoints = np.empty(0, dtype="int")
+    self.activeCells = np.empty(0, dtype="int")
+
+
+  def _computeActiveCells(self):
+    # Round each coordinate to the nearest cell.
+    flooredActivePoints = np.floor(self.activePoints).astype("int")
+
+    # Convert coordinates to cell numbers.
+    self.cellsForActivePoints = (
+      np.ravel_multi_index(flooredActivePoints.T, self.cellDimensions))
+    self.activeCells = np.unique(self.cellsForActivePoints)
+
+
+  def activateRandomLocation(self):
+    """
+    Set the location to a random point.
+    """
+    self.activePoints = np.array([np.random.random(2) * self.cellDimensions])
+    self._computeActiveCells()
+
+
+  def shift(self, deltaLocation):
+    """
+    Shift the current active cells by a vector.
+
+    @param deltaLocation (pair of floats)
+    A translation vector [di, dj].
+    """
+    # Calculate delta in the module's coordinates.
+    deltaLocationInCellFields = (np.matmul(self.rotationMatrix, deltaLocation) *
+                                 self.cellFieldsPerUnitDistance)
+
+    # Shift the active coordinates.
+    np.add(self.activePoints, deltaLocationInCellFields, out=self.activePoints)
+    np.mod(self.activePoints, self.cellDimensions, out=self.activePoints)
+
+    self._computeActiveCells()
+
+
+  def anchor(self, anchorInput):
+    """
+    Infer the location from sensory input. Activate any cells with enough active
+    synapses to this sensory input. Deactivate all other cells.
+
+    @param anchorInput (numpy array)
+    A sensory input. This will often come from a feature-location pair layer.
+    """
+    if len(anchorInput) == 0:
+      return
+
+    overlaps = self.connections.computeActivity(anchorInput,
+                                                self.connectedPermanence)
+    activeSegments = np.where(overlaps >= self.activationThreshold)[0]
+
+    sensorySupportedCells = np.unique(
+      self.connections.mapSegmentsToCells(activeSegments))
+
+    inactivated = np.setdiff1d(self.activeCells, sensorySupportedCells)
+    inactivatedIndices = np.in1d(self.cellsForActivePoints,
+                                 inactivated).nonzero()[0]
+    if inactivatedIndices.size > 0:
+      self.activePoints = np.delete(self.activePoints, inactivatedIndices,
+                                    axis=0)
+
+    activated = np.setdiff1d(sensorySupportedCells, self.activeCells)
+
+    activatedCoordsBase = np.transpose(
+      np.unravel_index(activated, self.cellDimensions)).astype('float')
+
+    activatedCoords = np.concatenate(
+      [activatedCoordsBase + [iOffset, jOffset]
+       for iOffset in self.pointOffsets
+       for jOffset in self.pointOffsets]
+    )
+    if activatedCoords.size > 0:
+      self.activePoints = np.append(self.activePoints, activatedCoords, axis=0)
+
+    self._computeActiveCells()
+    self.activeSegments = activeSegments
+
+
+  def learn(self, anchorInput):
+    """
+    Associate this location with a sensory input. Subsequently, anchorInput will
+    activate the current location during anchor().
+
+    @param anchorInput (numpy array)
+    A sensory input. This will often come from a feature-location pair layer.
+    """
+    overlaps = self.connections.computeActivity(anchorInput,
+                                                self.connectedPermanence)
+    activeSegments = np.where(overlaps >= self.activationThreshold)[0]
+
+    potentialOverlaps = self.connections.computeActivity(anchorInput)
+    matchingSegments = np.where(potentialOverlaps >=
+                                self.learningThreshold)[0]
+
+    # Cells with a active segment: reinforce the segment
+    cellsForActiveSegments = self.connections.mapSegmentsToCells(
+      activeSegments)
+    learningActiveSegments = activeSegments[
+      np.in1d(cellsForActiveSegments, self.activeCells)]
+    remainingCells = np.setdiff1d(self.activeCells, cellsForActiveSegments)
+
+    # Remaining cells with a matching segment: reinforce the best
+    # matching segment.
+    candidateSegments = self.connections.filterSegmentsByCell(
+      matchingSegments, remainingCells)
+    cellsForCandidateSegments = (
+      self.connections.mapSegmentsToCells(candidateSegments))
+    candidateSegments = candidateSegments[
+      np.in1d(cellsForCandidateSegments, remainingCells)]
+    onePerCellFilter = np2.argmaxMulti(potentialOverlaps[candidateSegments],
+                                       cellsForCandidateSegments)
+    learningMatchingSegments = candidateSegments[onePerCellFilter]
+
+    newSegmentCells = np.setdiff1d(remainingCells, cellsForCandidateSegments)
+
+    for learningSegments in (learningActiveSegments,
+                             learningMatchingSegments):
+      self._learn(self.connections, self.rng, learningSegments,
+                  anchorInput, potentialOverlaps,
+                  self.initialPermanence, self.sampleSize,
+                  self.permanenceIncrement, self.permanenceDecrement,
+                  self.maxSynapsesPerSegment)
+
+    # Remaining cells without a matching segment: grow one.
+    numNewSynapses = len(anchorInput)
+
+    if self.sampleSize != -1:
+      numNewSynapses = min(numNewSynapses, self.sampleSize)
+
+    if self.maxSynapsesPerSegment != -1:
+      numNewSynapses = min(numNewSynapses, self.maxSynapsesPerSegment)
+
+    newSegments = self.connections.createSegments(newSegmentCells)
+
+    self.connections.growSynapsesToSample(
+      newSegments, anchorInput, numNewSynapses,
+      self.initialPermanence, self.rng)
+
+    self.activeSegments = activeSegments
+
+
+  @staticmethod
+  def _learn(connections, rng, learningSegments, activeInput,
+             potentialOverlaps, initialPermanence, sampleSize,
+             permanenceIncrement, permanenceDecrement, maxSynapsesPerSegment):
+    """
+    Adjust synapse permanences, grow new synapses, and grow new segments.
+
+    @param learningActiveSegments (numpy array)
+    @param learningMatchingSegments (numpy array)
+    @param segmentsToPunish (numpy array)
+    @param activeInput (numpy array)
+    @param potentialOverlaps (numpy array)
+    """
+    # Learn on existing segments
+    connections.adjustSynapses(learningSegments, activeInput,
+                               permanenceIncrement, -permanenceDecrement)
+
+    # Grow new synapses. Calculate "maxNew", the maximum number of synapses to
+    # grow per segment. "maxNew" might be a number or it might be a list of
+    # numbers.
+    if sampleSize == -1:
+      maxNew = len(activeInput)
+    else:
+      maxNew = sampleSize - potentialOverlaps[learningSegments]
+
+    if maxSynapsesPerSegment != -1:
+      synapseCounts = connections.mapSegmentsToSynapseCounts(
+        learningSegments)
+      numSynapsesToReachMax = maxSynapsesPerSegment - synapseCounts
+      maxNew = np.where(maxNew <= numSynapsesToReachMax,
+                        maxNew, numSynapsesToReachMax)
+
+    connections.growSynapsesToSample(learningSegments, activeInput,
+                                     maxNew, initialPermanence, rng)
+
+
+  def getActiveCells(self):
+    return self.activeCells
+
+
+  def numberOfCells(self):
+    return np.prod(self.cellDimensions)

--- a/projects/location_layer/location_module_experiment/README.md
+++ b/projects/location_layer/location_module_experiment/README.md
@@ -1,0 +1,3 @@
+# Experiment: Infer 2D objects with location modules
+
+See: [Early findings with Location Modules](http://numenta.github.io/htmresearch/documents/location-layer/Early-findings-with-Location-Modules.html)

--- a/projects/location_layer/location_module_experiment/grid_2d_location_experiment.py
+++ b/projects/location_layer/location_module_experiment/grid_2d_location_experiment.py
@@ -1,0 +1,352 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+A shared experiment class for inferring 2D objects with location modules.
+"""
+
+import abc
+import random
+
+import numpy as np
+
+from htmresearch.algorithms.apical_tiebreak_temporal_memory import (
+  ApicalTiebreakTemporalMemory)
+from htmresearch.algorithms.column_pooler import ColumnPooler
+from htmresearch.algorithms.superficial_location_module import (
+  SuperficialLocationModule2D)
+
+
+class Grid2DLocationExperiment(object):
+  """
+  The experiment code organized into a class.
+  """
+
+  def __init__(self, objects, objectPlacements, featureNames, locationConfigs,
+               worldDimensions):
+
+    self.objects = objects
+    self.objectPlacements = objectPlacements
+    self.worldDimensions = worldDimensions
+
+    self.features = dict(
+      (k, np.array(sorted(random.sample(xrange(150), 15)), dtype="uint32"))
+      for k in featureNames)
+
+    self.locationModules = [SuperficialLocationModule2D(anchorInputSize=150*32,
+                                                        **config)
+                            for config in locationConfigs]
+
+    self.inputLayer = ApicalTiebreakTemporalMemory(**{
+      "columnCount": 150,
+      "cellsPerColumn": 32,
+      "basalInputSize": 18 * sum(np.prod(config["cellDimensions"])
+                                 for config in locationConfigs),
+      "apicalInputSize": 4096
+    })
+
+    self.objectLayer = ColumnPooler(**{
+      "inputWidth": 150 * 32
+    })
+
+    # Use these for classifying SDRs and for testing whether they're correct.
+    self.locationRepresentations = {
+      # Example:
+      # (objectName, (top, left)): [0, 26, 54, 77, 101, ...]
+    }
+    self.inputRepresentations = {
+      # Example:
+      # (objectName, (top, left), featureName): [0, 26, 54, 77, 101, ...]
+    }
+    self.objectRepresentations = {
+      # Example:
+      # objectName: [14, 19, 54, 107, 201, ...]
+    }
+
+    self.locationInWorld = None
+
+    self.maxSettlingTime = 10
+
+    self.monitors = {}
+    self.nextMonitorToken = 1
+
+
+  def addMonitor(self, monitor):
+    """
+    Subscribe to Grid2DLocationExperimentMonitor events.
+
+    @param monitor (Grid2DLocationExperimentMonitor)
+    An object that implements a set of monitor methods
+
+    @return (object)
+    An opaque object that can be used to refer to this monitor.
+    """
+
+    token = self.nextMonitorToken
+    self.nextMonitorToken += 1
+
+    self.monitors[token] = monitor
+
+    return token
+
+
+  def removeMonitor(self, monitorToken):
+    """
+    Unsubscribe from LocationExperiment events.
+
+    @param monitorToken (object)
+    The return value of addMonitor() from when this monitor was added
+    """
+    del self.monitors[monitorToken]
+
+
+  def getActiveLocationCells(self):
+    activeCells = np.array([], dtype="uint32")
+
+    totalPrevCells = 0
+    for i, module in enumerate(self.locationModules):
+      activeCells = np.append(activeCells,
+                              module.getActiveCells() + totalPrevCells)
+      totalPrevCells += module.numberOfCells()
+
+    return activeCells
+
+
+  def move(self, objectName, locationOnObject):
+    objectPlacement = self.objectPlacements[objectName]
+    locationInWorld = (objectPlacement[0] + locationOnObject[0],
+                       objectPlacement[1] + locationOnObject[1])
+
+    if self.locationInWorld is not None:
+      deltaLocation = (locationInWorld[0] - self.locationInWorld[0],
+                       locationInWorld[1] - self.locationInWorld[1])
+
+      for monitor in self.monitors.values():
+        monitor.beforeMove(deltaLocation)
+
+      params = {
+        "deltaLocation": deltaLocation
+      }
+      for module in self.locationModules:
+        module.shift(**params)
+
+      for monitor in self.monitors.values():
+        monitor.afterLocationShift(**params)
+
+    self.locationInWorld = locationInWorld
+    for monitor in self.monitors.values():
+      monitor.afterWorldLocationChanged(locationInWorld)
+
+
+  def _senseInferenceMode(self, featureSDR):
+    prevCellActivity = None
+    for i in xrange(self.maxSettlingTime):
+      inputParams = {
+        "activeColumns": featureSDR,
+        "basalInput": self.getActiveLocationCells(),
+        "apicalInput": self.objectLayer.getActiveCells(),
+        "learn": False
+      }
+      self.inputLayer.compute(**inputParams)
+
+      objectParams = {
+        "feedforwardInput": self.inputLayer.getActiveCells(),
+        "feedforwardGrowthCandidates": self.inputLayer.getPredictedActiveCells(),
+        "learn": False,
+      }
+      self.objectLayer.compute(**objectParams)
+
+      locationParams = {
+        "anchorInput": self.inputLayer.getActiveCells()
+      }
+      for module in self.locationModules:
+        module.anchor(**locationParams)
+
+      cellActivity = (set(self.objectLayer.getActiveCells()),
+                      set(self.inputLayer.getActiveCells()),
+                      set(self.getActiveLocationCells()))
+
+      if cellActivity == prevCellActivity:
+        # It settled. Don't even log this timestep.
+        break
+      else:
+        prevCellActivity = cellActivity
+        for monitor in self.monitors.values():
+          if i > 0:
+            monitor.markSensoryRepetition()
+
+          monitor.afterInputCompute(**inputParams)
+          monitor.afterObjectCompute(**objectParams)
+          monitor.afterLocationAnchor(**locationParams)
+
+
+  def _senseLearningMode(self, featureSDR):
+    inputParams = {
+      "activeColumns": featureSDR,
+      "basalInput": self.getActiveLocationCells(),
+      "apicalInput": self.objectLayer.getActiveCells(),
+      "learn": True
+    }
+    self.inputLayer.compute(**inputParams)
+
+    objectParams = {
+      "feedforwardInput": self.inputLayer.getActiveCells(),
+      "feedforwardGrowthCandidates": self.inputLayer.getPredictedActiveCells(),
+      "learn": True,
+    }
+    self.objectLayer.compute(**objectParams)
+
+    locationParams = {
+      "anchorInput": self.inputLayer.getWinnerCells()
+    }
+    for module in self.locationModules:
+      module.learn(**locationParams)
+
+    for monitor in self.monitors.values():
+      monitor.afterInputCompute(**inputParams)
+      monitor.afterObjectCompute(**objectParams)
+
+
+  def sense(self, featureSDR, learn):
+    for monitor in self.monitors.values():
+      monitor.beforeSense(featureSDR)
+
+    if learn:
+      self._senseLearningMode(featureSDR)
+    else:
+      self._senseInferenceMode(featureSDR)
+
+
+  def learnObjects(self):
+    """
+    Learn each provided object.
+
+    This method simultaneously learns 4 sets of synapses:
+    - location -> input
+    - input -> location
+    - input -> object
+    - object -> input
+    """
+    for objectName, objectFeatures in self.objects.iteritems():
+      self.reset()
+
+      for module in self.locationModules:
+        module.activateRandomLocation()
+
+      for feature in objectFeatures:
+        locationOnObject = (feature["top"] + feature["height"]/2,
+                            feature["left"] + feature["width"]/2)
+        self.move(objectName, locationOnObject)
+
+        featureName = feature["name"]
+        featureSDR = self.features[featureName]
+        for _ in xrange(10):
+          self.sense(featureSDR, learn=True)
+
+        self.locationRepresentations[(objectName, locationOnObject)] = (
+          self.getActiveLocationCells())
+        self.inputRepresentations[(objectName, locationOnObject, featureName)] = (
+          self.inputLayer.getActiveCells())
+
+      self.objectRepresentations[objectName] = self.objectLayer.getActiveCells()
+
+
+  def inferObjectsWithRandomMovements(self):
+    """
+    Infer each object without any location input.
+    """
+    for objectName, objectFeatures in self.objects.iteritems():
+      self.reset()
+
+      inferred = False
+      prevTouchSequence = None
+
+      for _ in xrange(4):
+
+        while True:
+          touchSequence = list(objectFeatures)
+          random.shuffle(touchSequence)
+
+          if prevTouchSequence is not None:
+            if touchSequence[0] == prevTouchSequence[-1]:
+              continue
+
+          break
+
+        for i, feature in enumerate(touchSequence):
+          locationOnObject = (feature["top"] + feature["height"]/2,
+                              feature["left"] + feature["width"]/2)
+          self.move(objectName, locationOnObject)
+
+          featureName = feature["name"]
+          featureSDR = self.features[featureName]
+          self.sense(featureSDR, learn=False)
+
+          inferred = (
+            set(self.objectLayer.getActiveCells()) ==
+            set(self.objectRepresentations[objectName]) and
+
+            set(self.inputLayer.getActiveCells()) ==
+            set(self.inputRepresentations[(objectName,
+                                           locationOnObject,
+                                           featureName)]) and
+
+            set(self.getActiveLocationCells()) ==
+            set(self.locationRepresentations[(objectName, locationOnObject)]))
+
+          if inferred:
+            break
+
+        prevTouchSequence = touchSequence
+
+        if inferred:
+          break
+
+
+  def reset(self):
+    for module in self.locationModules:
+      module.reset()
+    self.objectLayer.reset()
+    self.inputLayer.reset()
+
+    self.locationInWorld = None
+
+    for monitor in self.monitors.values():
+      monitor.afterReset()
+
+
+
+class Grid2DLocationExperimentMonitor(object):
+  """
+  Abstract base class for a Grid2DLocationExperiment monitor.
+  """
+
+  __metaclass__ = abc.ABCMeta
+
+  def beforeSense(self, featureSDR): pass
+  def beforeMove(self, deltaLocation): pass
+  def markSensoryRepetition(self): pass
+  def afterReset(self): pass
+  def afterWorldLocationChanged(self, locationInWorld): pass
+  def afterLocationShift(self, **kwargs): pass
+  def afterLocationAnchor(self, **kwargs): pass
+  def afterInputCompute(self, **kwargs): pass
+  def afterObjectCompute(self, **kwargs): pass

--- a/projects/location_layer/location_module_experiment/tracing.py
+++ b/projects/location_layer/location_module_experiment/tracing.py
@@ -1,0 +1,299 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Connect the Grid2DLocationExperiment to the locationModuleInference.js
+visualization.
+"""
+
+from __future__ import print_function
+from collections import defaultdict
+import json
+
+import numpy as np
+
+from grid_2d_location_experiment import Grid2DLocationExperimentMonitor
+
+
+
+class Grid2DLocationExperimentVisualizer(Grid2DLocationExperimentMonitor):
+  """
+  Logs the state of the world and the state of each layer to a file.
+  """
+
+  def __init__(self, exp, out, includeSynapses=True):
+    self.exp = exp
+    self.out = out
+    self.includeSynapses = includeSynapses
+
+    self.locationRepresentations = exp.locationRepresentations
+    self.inputRepresentations = exp.inputRepresentations
+    self.objectRepresentations = exp.objectRepresentations
+
+    self.locationModules = exp.locationModules
+    self.inputLayer = exp.inputLayer
+    self.objectLayer = exp.objectLayer
+
+    self.subscriberToken = exp.addMonitor(self)
+
+    # World dimensions
+    print(json.dumps({"width": exp.worldDimensions[1],
+                      "height": exp.worldDimensions[0]}),
+          file=self.out)
+
+    print(json.dumps({"A": "red",
+                      "B": "blue",
+                      "C": "gray"}),
+          file=self.out)
+    print(json.dumps(exp.objects), file=self.out)
+
+    print(json.dumps([{"cellDimensions": module.cellDimensions.tolist(),
+                       "moduleMapDimensions": module.moduleMapDimensions.tolist(),
+                       "orientation": module.orientation}
+                      for module in exp.locationModules]),
+          file=self.out)
+
+    print("objectPlacements", file=self.out)
+    print(json.dumps(exp.objectPlacements), file=self.out)
+
+
+  def __enter__(self, *args):
+    pass
+
+
+  def __exit__(self, *args):
+    self.unsubscribe()
+
+
+  def unsubscribe(self):
+
+    self.exp.removeMonitor(self.subscriberToken)
+    self.subscriberToken = None
+
+
+  def beforeSense(self, featureSDR):
+    print("sense", file=self.out)
+    print(json.dumps(featureSDR.tolist()), file=self.out)
+    print(json.dumps(
+      [k
+       for k, sdr in self.exp.features.iteritems()
+       if np.intersect1d(featureSDR, sdr).size == sdr.size]), file=self.out)
+
+
+  def beforeMove(self, deltaLocation):
+    print("move", file=self.out)
+    print(json.dumps(list(deltaLocation)), file=self.out)
+
+
+  def afterReset(self):
+    print("reset", file=self.out)
+
+
+  def markSensoryRepetition(self):
+    print("sensoryRepetition", file=self.out)
+
+
+  def afterWorldLocationChanged(self, locationInWorld):
+    print("locationInWorld", file=self.out)
+    print(json.dumps(locationInWorld), file=self.out)
+
+
+  def afterLocationShift(self, deltaLocation):
+    print("shift", file=self.out)
+
+    cellsByModule = [module.getActiveCells().tolist()
+                     for module in self.locationModules]
+    print(json.dumps(cellsByModule), file=self.out)
+
+    pointsByModule = []
+    for module in self.locationModules:
+      pointsByModule.append(module.activePoints.tolist())
+    print(json.dumps(pointsByModule), file=self.out)
+
+    activeLocationCells = self.exp.getActiveLocationCells()
+
+    decodings = []
+    for (objectName, location), sdr in self.locationRepresentations.iteritems():
+      amountContained = (np.intersect1d(sdr, activeLocationCells).size /
+                         float(sdr.size))
+      if amountContained >= 0.05:
+        decodings.append(
+          [objectName, location[0], location[1], amountContained])
+
+    print(json.dumps(decodings), file=self.out)
+
+
+  def afterLocationAnchor(self, anchorInput):
+    print("locationLayer", file=self.out)
+
+    cellsByModule = []
+    for module in self.locationModules:
+      activeCells = module.getActiveCells()
+
+      if self.includeSynapses:
+        segmentsForActiveCellsDict = defaultdict(list)
+
+        activeSegments = module.connections.filterSegmentsByCell(
+          module.activeSegments, activeCells)
+        cellForActiveSegments = (
+          module.connections.mapSegmentsToCells(activeSegments))
+
+        for i, segment in enumerate(activeSegments):
+          connectedSynapses = np.where(
+            module.connections.matrix.getRow(segment)
+            >= module.connectedPermanence)[0]
+
+          activeSynapses = np.intersect1d(connectedSynapses, anchorInput)
+          segmentsForActiveCellsDict[cellForActiveSegments[i]].append(
+            activeSynapses.tolist())
+
+        segmentsForActiveCells = [segmentsForActiveCellsDict[cell]
+                                  for cell in activeCells]
+
+        cellsByModule.append([activeCells.tolist(),
+                              {"inputLayer": segmentsForActiveCells}])
+      else:
+        cellsByModule.append([activeCells.tolist()])
+
+    print(json.dumps(cellsByModule), file=self.out)
+
+    pointsByModule = []
+    for module in self.locationModules:
+      pointsByModule.append(module.activePoints.tolist())
+    print(json.dumps(pointsByModule), file=self.out)
+
+
+    activeLocationCells = self.exp.getActiveLocationCells()
+
+    decodings = []
+    for (objectName, location), sdr in self.locationRepresentations.iteritems():
+      amountContained = (np.intersect1d(sdr, activeLocationCells).size /
+                         float(sdr.size))
+      if amountContained >= 0.05:
+        decodings.append(
+          [objectName, location[0], location[1], amountContained])
+    print(json.dumps(decodings), file=self.out)
+
+
+  def getInputSegments(self, cells, basalInput, apicalInput):
+    basalSegmentsForCellDict = defaultdict(list)
+
+    basalSegments = self.inputLayer.basalConnections.filterSegmentsByCell(
+      self.inputLayer.activeBasalSegments, cells)
+    cellForBasalSegment = self.inputLayer.basalConnections.mapSegmentsToCells(
+      basalSegments)
+
+    for i, segment in enumerate(basalSegments):
+      connectedSynapses = np.where(
+        self.inputLayer.basalConnections.matrix.getRow(
+          segment) >= self.inputLayer.connectedPermanence)[0]
+
+      activeSynapses = np.intersect1d(connectedSynapses, basalInput)
+      basalSegmentsForCellDict[cellForBasalSegment[i]].append(
+        activeSynapses.tolist())
+
+    apicalSegmentsForCellDict = defaultdict(list)
+
+    apicalSegments = self.inputLayer.apicalConnections.filterSegmentsByCell(
+      self.inputLayer.activeApicalSegments, cells)
+    cellForApicalSegment = (
+      self.inputLayer.apicalConnections.mapSegmentsToCells(apicalSegments))
+
+    for i, segment in enumerate(apicalSegments):
+      connectedSynapses = np.where(
+        self.inputLayer.apicalConnections.matrix.getRow(segment)
+        >= self.inputLayer.connectedPermanence)[0]
+
+      activeSynapses = np.intersect1d(connectedSynapses, apicalInput)
+      apicalSegmentsForCellDict[cellForApicalSegment[i]].append(
+        activeSynapses.tolist())
+
+    return {
+      "locationLayer": [basalSegmentsForCellDict[cell] for cell in cells],
+      "objectLayer": [apicalSegmentsForCellDict[cell] for cell in cells],
+    }
+
+
+  def getInputDecodings(self, activeCells):
+    decodings = []
+    for (objectName, location, feature), sdr in self.inputRepresentations.iteritems():
+      amountContained = (np.intersect1d(sdr, activeCells).size /
+                         float(sdr.size))
+      if amountContained >= 0.05:
+        decodings.append([objectName, location[0], location[1], amountContained])
+
+    return decodings
+
+
+  def afterInputCompute(self, activeColumns, basalInput, apicalInput, **kwargs):
+    activeCells = self.inputLayer.getActiveCells().tolist()
+    predictedCells = self.inputLayer.getPredictedCells().tolist()
+
+    print("inputLayer", file=self.out)
+
+    if self.includeSynapses:
+      segmentsForActiveCells = self.getInputSegments(activeCells, basalInput,
+                                                     apicalInput)
+      segmentsForPredictedCells = self.getInputSegments(predictedCells, basalInput,
+                                                        apicalInput)
+
+      print(json.dumps(
+        [activeCells, predictedCells, segmentsForActiveCells,
+         segmentsForPredictedCells]), file=self.out)
+
+    else:
+      print(json.dumps(
+        [activeCells, predictedCells]), file=self.out)
+
+    print(json.dumps({
+      "activeCellDecodings": self.getInputDecodings(activeCells),
+      "predictedCellDecodings": self.getInputDecodings(predictedCells)
+    }), file=self.out)
+
+
+  def afterObjectCompute(self, feedforwardInput, **kwargs):
+    activeCells = self.objectLayer.getActiveCells()
+
+    cells = dict((cell, [])
+                 for cell in activeCells.tolist())
+
+    print("objectLayer", file=self.out)
+    if self.includeSynapses:
+      segmentsForActiveCells = [[] for _ in activeCells]
+
+      for i, cell in enumerate(activeCells):
+        connectedSynapses = np.where(
+          self.objectLayer.proximalPermanences.getRow(cell)
+          >= self.objectLayer.connectedPermanenceProximal)[0]
+
+        activeSynapses = np.intersect1d(connectedSynapses, feedforwardInput)
+        segmentsForActiveCells[i].append(activeSynapses.tolist())
+
+      print(json.dumps([activeCells.tolist(),
+                        {"inputLayer": segmentsForActiveCells}]),
+            file=self.out)
+    else:
+      print(json.dumps([activeCells.tolist()]), file=self.out)
+
+    decodings = [k
+                 for k, sdr in self.objectRepresentations.iteritems()
+                 if np.intersect1d(activeCells, sdr).size == sdr.size]
+    print(json.dumps(decodings), file=self.out)

--- a/projects/location_layer/location_module_experiment/visualize_discrete_objects.py
+++ b/projects/location_layer/location_module_experiment/visualize_discrete_objects.py
@@ -113,11 +113,17 @@ def doExperiment(cellDimensions, pointOffsets):
 
   exp.learnObjects()
 
-  filename = "logs/{}-points-{}-cells.log".format(len(pointOffsets)**2,
-                                                  np.prod(cellDimensions))
-  with open(filename, "w") as fileOut:
-    print "Logging to", filename
-    with trace(exp, fileOut, includeSynapses=False):
+  filename = "logs/{}-points-{}-cells.log".format(
+    len(pointOffsets)**2, np.prod(cellDimensions))
+  synapseFilename = "logs/{}-points-{}-cells-synapses.log".format(
+    len(pointOffsets)**2, np.prod(cellDimensions))
+
+  with open(filename, "w") as fileOut, \
+       open(synapseFilename, "w") as synapseFileOut:
+    with trace(exp, fileOut, includeSynapses=False), \
+         trace(exp, synapseFileOut, includeSynapses=True):
+      print "Logging to", filename
+      print "Logging to", synapseFilename
       exp.inferObjectsWithRandomMovements()
 
 

--- a/projects/location_layer/location_module_experiment/visualize_discrete_objects.py
+++ b/projects/location_layer/location_module_experiment/visualize_discrete_objects.py
@@ -1,0 +1,138 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Mimic the single_layer_2d_experiment, but this time use location modules.
+"""
+
+import math
+import os
+import random
+
+import numpy as np
+
+from grid_2d_location_experiment import Grid2DLocationExperiment
+from tracing import Grid2DLocationExperimentVisualizer as trace
+
+
+DISCRETE_OBJECTS = {
+  "Object 1": {(0,0): "A",
+               (0,1): "B",
+               (0,2): "A",
+               (1,0): "A",
+               (1,2): "A"},
+  "Object 2": {(0,1): "A",
+               (1,0): "B",
+               (1,1): "B",
+               (1,2): "B",
+               (2,1): "A"},
+  "Object 3": {(0,1): "A",
+               (1,0): "A",
+               (1,1): "B",
+               (1,2): "A",
+               (2,0): "B",
+               (2,1): "A",
+               (2,2): "B"},
+  "Object 4": {(0,0): "A",
+               (0,1): "A",
+               (0,2): "A",
+               (1,0): "A",
+               (1,2): "B",
+               (2,0): "B",
+               (2,1): "B",
+               (2,2): "B"},
+}
+
+DISCRETE_OBJECT_PLACEMENTS = {
+  "Object 1": (2, 3),
+  "Object 2": (6, 2),
+  "Object 3": (3, 7),
+  "Object 4": (7, 6)
+}
+
+CM_PER_UNIT = 100.0 / 12.0
+
+
+def doExperiment(cellDimensions, pointOffsets):
+  if not os.path.exists("logs"):
+    os.makedirs("logs")
+
+  objects = dict(
+    (objectName, [{"top": location[0] * CM_PER_UNIT,
+                   "left": location[1] * CM_PER_UNIT,
+                   "width": CM_PER_UNIT,
+                   "height": CM_PER_UNIT,
+                   "name": featureName}
+                  for location, featureName in objectDict.iteritems()])
+    for objectName, objectDict in DISCRETE_OBJECTS.iteritems())
+
+  objectPlacements = dict(
+    (objectName, [placement[0] * CM_PER_UNIT,
+                  placement[1] * CM_PER_UNIT])
+    for objectName, placement in DISCRETE_OBJECT_PLACEMENTS.iteritems())
+
+  locationConfigs = []
+  for i in xrange(9):
+    scale = 10.0 * (math.sqrt(2) ** i)
+
+    for _ in xrange(2):
+      orientation = random.gauss(7.5, 7.5) * math.pi / 180.0
+      orientation = random.choice([orientation, -orientation])
+
+      locationConfigs.append({
+        "cellDimensions": cellDimensions,
+        "moduleMapDimensions": (scale, scale),
+        "orientation": orientation,
+        "pointOffsets": pointOffsets,
+      })
+
+  exp = Grid2DLocationExperiment(
+    featureNames=("A", "B"),
+    objects=objects,
+    objectPlacements=objectPlacements,
+    locationConfigs=locationConfigs,
+    worldDimensions=(100, 100))
+
+  exp.learnObjects()
+
+  filename = "logs/{}-points-{}-cells.log".format(len(pointOffsets)**2,
+                                                  np.prod(cellDimensions))
+  with open(filename, "w") as fileOut:
+    print "Logging to", filename
+    with trace(exp, fileOut, includeSynapses=False):
+      exp.inferObjectsWithRandomMovements()
+
+
+
+if __name__ == "__main__":
+  doExperiment(cellDimensions=(5, 5),
+               pointOffsets=(0.5,))
+
+  doExperiment(cellDimensions=(5, 5),
+               pointOffsets=(0.05, 0.5, 0.95))
+
+  doExperiment(cellDimensions=(10, 10),
+               pointOffsets=(0.05, 0.5, 0.95))
+
+  print "Visualize these logs at:"
+  print "http://numenta.github.io/htmresearch/visualizations/location-layer/location-module-inference.html"
+  print ("or in a Jupyter notebook with the htmresearchviz0 package and the "
+         "printLocationModuleInference function.")

--- a/projects/location_layer/location_module_experiment/visualize_location_modules.py
+++ b/projects/location_layer/location_module_experiment/visualize_location_modules.py
@@ -1,0 +1,104 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Visualize an array of location modules while moving a sensor along simple paths.
+"""
+
+from __future__ import print_function
+import csv
+import json
+import math
+import os
+import random
+
+from htmresearch.algorithms.superficial_location_module import (
+  SuperficialLocationModule2D)
+
+
+def go():
+  if not os.path.exists("logs"):
+    os.makedirs("logs")
+
+  filename = "logs/isolated-modules.log"
+  with open(filename, "w") as fileOut:
+    print ("Logging to", filename)
+
+    worldWidth = 100.0
+    worldHeight = 100.0
+
+    stepsPerScale = 5
+
+    locationConfigs = []
+    for i in xrange(9):
+      scale = 10.0 * (math.sqrt(2) ** i)
+
+      for _ in xrange(2):
+        orientation = random.gauss(7.5, 7.5) * math.pi / 180.0
+        orientation = random.choice([orientation, -orientation])
+
+        locationConfigs.append({
+          "cellDimensions": (5, 5),
+          "moduleMapDimensions": (scale, scale),
+          "orientation": orientation,
+          "pointOffsets": (0.5,),
+        })
+
+    print(json.dumps({"width": worldWidth,
+                      "height": worldHeight}), file=fileOut)
+    print(json.dumps(locationConfigs), file=fileOut)
+
+    modules = [SuperficialLocationModule2D(anchorInputSize=0, **config)
+               for config in locationConfigs]
+
+    location = [5.0, 5.0]
+
+    for module in modules:
+      module.activateRandomLocation()
+
+    for deltaLocation in 30*[[2.0, 2.5]]:
+      location[0] += deltaLocation[0]
+      location[1] += deltaLocation[1]
+
+      print("move", file=fileOut)
+      print(json.dumps(list(deltaLocation)), file=fileOut)
+      print("locationInWorld", file=fileOut)
+      print(json.dumps(location), file=fileOut)
+
+      for module in modules:
+        module.shift(deltaLocation)
+
+      print("shift", file=fileOut)
+      cellsByModule = [module.getActiveCells().tolist()
+                       for module in modules]
+      print(json.dumps(cellsByModule), file=fileOut)
+      pointsByModule = []
+      for module in modules:
+        pointsByModule.append(module.activePoints.tolist())
+      print(json.dumps(pointsByModule), file=fileOut)
+
+
+if __name__ == "__main__":
+  go()
+  print("Visualize this CSV file at:")
+  print("http://numenta.github.io/htmresearch/visualizations/location-layer/location-modules.html")
+  print("or in a Jupyter notebook with the htmresearchviz0 package and the "
+        "printLocationModulesRecording function.")

--- a/projects/location_layer/visualizations/README.md
+++ b/projects/location_layer/visualizations/README.md
@@ -13,9 +13,15 @@ npm install
 
 cd py/
 python setup.py develop --user
+
+cd ..
+npm run dev
 ~~~
 
-Now, in a Jupyter notebook, include:
+This final command watches for changes to .js files, and it also launches a
+webserver where you can use the various log viewers.
+
+If you want to use Jupyter notebook, include:
 
 ~~~python
 import htmresearchviz0.IPython_support as viz

--- a/projects/location_layer/visualizations/js/index.js
+++ b/projects/location_layer/visualizations/js/index.js
@@ -1,1 +1,9 @@
-export {printRecording, printRecordingFromUrl} from "./src/singleLayer2D";
+import * as locationModuleInference from "./src/locationModuleInference";
+import * as locationModules from "./src/locationModules";
+
+export {printRecording,
+        printRecordingFromUrl}
+  from "./src/singleLayer2D";
+
+export {locationModuleInference};
+export {locationModules};

--- a/projects/location_layer/visualizations/js/src/charts/arrayOfAxonsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/arrayOfAxonsChart.js
@@ -1,0 +1,63 @@
+import * as d3 from "d3";
+
+/**
+ * Example params:
+ * {
+ *   inputSize: 100,
+ *   activeBits: [42, 45]
+ * }
+ */
+function arrayOfAxonsChart() {
+  let width,
+      height;
+
+  let chart = function(selection) {
+    selection.each(function(axonsData) {
+      let x = d3.scaleLinear()
+          .domain([0, axonsData.inputSize])
+          .range([4, width - 4]);
+
+      d3.select(this)
+        .selectAll('.border')
+        .data([null])
+        .enter().append('rect')
+        .attr('class', 'border')
+        .attr('fill', 'none')
+        .attr('stroke', 'black')
+        .attr('width', width)
+        .attr('height', height);
+
+      let activeAxon = d3.select(this).selectAll('.activeAxon')
+          .data(d => d.activeBits);
+
+      activeAxon.enter().append('g')
+        .attr('class', 'activeAxon')
+        .call(enter => {
+          enter.append('circle')
+            .attr('r', 1.5)
+            .attr('stroke', 'none')
+            .attr('fill', 'black');
+        })
+        .merge(activeAxon)
+        .attr('transform', cell => `translate(${x(cell)}, 2.5)`);
+
+      activeAxon.exit().remove();
+    });
+  };
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {arrayOfAxonsChart};

--- a/projects/location_layer/visualizations/js/src/charts/decodedLocationsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/decodedLocationsChart.js
@@ -1,0 +1,173 @@
+import * as d3 from "d3";
+import {featureChart} from './featureChart.js';
+
+function partition(arr, n) {
+  let result = [];
+
+  for (let i = 0; i < arr.length; i += n) {
+    result.push(arr.slice(i, i+n));
+  }
+
+  return result;
+}
+
+/**
+ * Example data:
+ *    {decodings: [{objectName: 'Object 1', top: 42.0, left: 17.2, amountContained: 0.95}],
+ *     objects: {'Object 1': [{name: 'A', left: 11.2, top:12.0, width: 12.2, height: 7.2}],
+ *               'Object 2': []}}
+ */
+function decodedLocationsChart() {
+  let width,
+      height,
+      color,
+      minimumMatch = 0.25;
+
+  let chart = function(selection) {
+
+    selection.each(function(decodedLocationsData) {
+      let decodingsByObject = {};
+      decodedLocationsData.decodings.forEach(d => {
+        if (d.amountContained >= minimumMatch) {
+          if (!decodingsByObject.hasOwnProperty(d.objectName)) {
+            decodingsByObject[d.objectName] = [];
+          }
+
+          decodingsByObject[d.objectName].push(d);
+        }
+      });
+
+      let decodings = [],
+          maxWidth = 0,
+          maxHeight = 0;
+      for (let objectName in decodingsByObject) {
+        decodings.push([objectName, decodingsByObject[objectName]]);
+
+        decodedLocationsData.objects[objectName].forEach(d => {
+          maxWidth = Math.max(maxWidth, d.left + d.width);
+          maxHeight = Math.max(maxHeight, d.top + d.height);
+        });
+      }
+
+      // Sort by object name.
+      decodings.sort((a,b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+
+      let rows = partition(decodings, 3);
+
+      let decodedObjectRow = d3.select(this).selectAll('.decodedObjectRow')
+          .data(rows);
+
+      decodedObjectRow.exit().remove();
+
+      decodedObjectRow = decodedObjectRow.enter().append('g')
+        .attr('class', 'decodedObjectRow')
+        .attr('transform', (d,i) => `translate(0,${i == 0 ? 0 : i*height/3 + 10})`)
+        .merge(decodedObjectRow);
+
+      let decodedObject = decodedObjectRow.selectAll('.decodedObject')
+          .data(d => d);
+
+      decodedObject.exit().remove();
+
+      decodedObject = decodedObject.enter().append('g')
+        .attr('class', 'decodedObject')
+        .attr('transform', (d, i) => `translate(${i*width/3},0)`)
+        .call(enter => {
+          enter.append('g')
+            .attr('class', 'features');
+          enter.append('g')
+              .attr('class', 'points')
+            .append('rect')
+              .attr('width', width/3)
+              .attr('height', height/3)
+              .attr('fill', 'white')
+              .attr('fill-opacity', 0.7);
+        })
+        .merge(decodedObject);
+
+      decodedObject.each(function([objectName, decodedLocations]) {
+
+        let cmMax = Math.max(maxWidth, maxHeight);
+        let pxMax = Math.min(width/3, height/3);
+        let x = d3.scaleLinear()
+            .domain([0, cmMax])
+            .range([0, pxMax]);
+        let y = d3.scaleLinear()
+            .domain([0, cmMax])
+            .range([0, pxMax]);
+
+        let feature = d3.select(this).select('.features').selectAll('.feature')
+            .data(decodedLocationsData.objects[objectName]);
+
+        feature.exit().remove();
+
+        feature = feature.enter()
+          .append('g')
+          .attr('class', 'feature')
+          .merge(feature)
+          .attr('transform', d => `translate(${x(d.left)},${y(d.top)})`)
+          .each(function(featureData) {
+            d3.select(this)
+              .call(featureChart()
+                    .width(x(featureData.width))
+                    .height(y(featureData.height))
+                    .color(color));
+          });
+
+        let point = d3.select(this).select('.points').selectAll('.point')
+            .data(decodedLocations);
+
+        point.exit().remove();
+
+        point = point.enter().append('g')
+            .attr('class', 'point')
+          .call(enter => {
+            enter.append('circle')
+              .attr('r', 3)
+              .attr('fill', 'white')
+              .attr('stroke', 'black');
+
+            enter.append('path')
+              .attr('fill', 'black')
+              .attr('stroke', 'none');
+          }).merge(point)
+            .attr('transform', d => `translate(${x(d.left)},${y(d.top)})`);
+
+        point.select('path')
+          .attr('d', d3.arc()
+                .innerRadius(0)
+                .outerRadius(3)
+                .startAngle(0)
+                .endAngle(d => d.amountContained / 1.0 * 2 * Math.PI));
+      });
+    });
+  };
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.color = function(_) {
+    if (!arguments.length) return color;
+    color = _;
+    return chart;
+  };
+
+  chart.minimumMatch = function(_) {
+    if (!arguments.length) return minimumMatch;
+    minimumMatch = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {decodedLocationsChart};

--- a/projects/location_layer/visualizations/js/src/charts/decodedLocationsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/decodedLocationsChart.js
@@ -61,7 +61,7 @@ function decodedLocationsChart() {
 
       decodedObjectRow = decodedObjectRow.enter().append('g')
         .attr('class', 'decodedObjectRow')
-        .attr('transform', (d,i) => `translate(0,${i == 0 ? 0 : i*height/3 + 10})`)
+        .attr('transform', (d,i) => `translate(0,${i == 0 ? 0 : i*height/2.5 + 10})`)
         .merge(decodedObjectRow);
 
       let decodedObject = decodedObjectRow.selectAll('.decodedObject')
@@ -79,7 +79,7 @@ function decodedLocationsChart() {
               .attr('class', 'points')
             .append('rect')
               .attr('width', width/3)
-              .attr('height', height/3)
+              .attr('height', height/2.5)
               .attr('fill', 'white')
               .attr('fill-opacity', 0.7);
         })
@@ -88,7 +88,7 @@ function decodedLocationsChart() {
       decodedObject.each(function([objectName, decodedLocations]) {
 
         let cmMax = Math.max(maxWidth, maxHeight);
-        let pxMax = Math.min(width/3, height/3);
+        let pxMax = Math.min(width/3, height/2.5);
         let x = d3.scaleLinear()
             .domain([0, cmMax])
             .range([0, pxMax]);
@@ -123,9 +123,9 @@ function decodedLocationsChart() {
             .attr('class', 'point')
           .call(enter => {
             enter.append('circle')
-              .attr('r', 3)
+              .attr('r', 4)
               .attr('fill', 'white')
-              .attr('stroke', 'black');
+              .attr('stroke', 'none');
 
             enter.append('path')
               .attr('fill', 'black')
@@ -136,7 +136,7 @@ function decodedLocationsChart() {
         point.select('path')
           .attr('d', d3.arc()
                 .innerRadius(0)
-                .outerRadius(3)
+                .outerRadius(4)
                 .startAngle(0)
                 .endAngle(d => d.amountContained / 1.0 * 2 * Math.PI));
       });

--- a/projects/location_layer/visualizations/js/src/charts/decodedObjectsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/decodedObjectsChart.js
@@ -1,0 +1,117 @@
+import * as d3 from "d3";
+import {featureChart} from './featureChart.js';
+
+function partition(arr, n) {
+  let result = [];
+
+  for (let i = 0; i < arr.length; i += n) {
+    result.push(arr.slice(i, i+n));
+  }
+
+  return result;
+}
+
+/**
+ * Example data:
+ *    {decodings: ['Object 1', 'Object 2'],
+ *     objects: {'Object 1': [{name: 'A', top: 42.0, left: 17.2, width: 12.2, height: 7.2}],
+ *               'Object 2': []}}
+ */
+function decodedObjectsChart() {
+  let width,
+      height,
+      color;
+
+  let chart = function(selection) {
+
+    selection.each(function(decodedObjectsData) {
+
+      let maxWidth = 0,
+          maxHeight = 0;
+      decodedObjectsData.decodings.forEach(objectName => {
+        decodedObjectsData.objects[objectName].forEach(d => {
+          maxWidth = Math.max(maxWidth, d.left + d.width);
+          maxHeight = Math.max(maxHeight, d.top + d.height);
+        });
+      });
+
+      let decodings = decodedObjectsData.decodings.slice();
+
+      // Sort by object name.
+      decodings.sort();
+
+      let rows = partition(decodings, 3);
+
+      let decodedObjectRow = d3.select(this).selectAll('.decodedObjectRow')
+          .data(rows);
+
+      decodedObjectRow.exit().remove();
+
+      decodedObjectRow = decodedObjectRow.enter().append('g')
+        .attr('class', 'decodedObjectRow')
+        .attr('transform', (d,i) => `translate(0,${i == 0 ? 0 : i*height/3 + 10})`)
+        .merge(decodedObjectRow);
+
+      let decodedObject = decodedObjectRow.selectAll('.decodedObject')
+          .data(d => d);
+
+      decodedObject.exit().remove();
+
+      decodedObject = decodedObject.enter().append('g')
+        .attr('class', 'decodedObject')
+        .attr('transform', (d, i) => `translate(${i*width/3},0)`)
+        .merge(decodedObject);
+
+      decodedObject.each(function(objectName) {
+        let cmMax = Math.max(maxWidth, maxHeight);
+        let pxMax = Math.min(width/3, height/3);
+        let x = d3.scaleLinear()
+            .domain([0, cmMax])
+            .range([0, pxMax]);
+        let y = d3.scaleLinear()
+            .domain([0, cmMax])
+            .range([0, pxMax]);
+
+        let feature = d3.select(this).selectAll('.feature')
+            .data(decodedObjectsData.objects[objectName]);
+
+        feature.exit().remove();
+
+        feature.enter()
+          .append('g')
+          .attr('class', 'feature')
+          .merge(feature)
+          .attr('transform', d => `translate(${x(d.left)},${y(d.top)})`)
+          .each(function(featureData) {
+            d3.select(this)
+              .call(featureChart()
+                    .width(x(featureData.width))
+                    .height(y(featureData.height))
+                    .color(color));
+          });
+      });
+    });
+  };
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.color = function(_) {
+    if (!arguments.length) return color;
+    color = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {decodedObjectsChart};

--- a/projects/location_layer/visualizations/js/src/charts/featureChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/featureChart.js
@@ -1,0 +1,66 @@
+import * as d3 from "d3";
+
+/**
+ * Example data:
+ *    {name: 'A'}
+ */
+function featureChart() {
+  let width,
+      height,
+      color;
+
+  let chart = function(selection) {
+    let featureColor = selection.selectAll('.featureColor')
+        .data(d => d.name != null ? [d.name] : []);
+
+    featureColor.exit().remove();
+
+    featureColor.enter()
+      .append('rect')
+      .attr('class', 'featureColor')
+      .attr('width', width)
+      .attr('height', height)
+      .attr('stroke', 'none')
+      .merge(featureColor)
+      .attr('fill', d => color(d));
+
+    let featureText = selection.selectAll('.featureText')
+        .data(d => d.name != null ? [d.name] : []);
+
+    featureText.exit().remove();
+
+    featureText.enter()
+      .append('text')
+      .attr('class', 'featureText')
+      .attr('text-anchor', 'middle')
+      .attr('dy', height * 0.25)
+      .attr('x', width / 2)
+      .attr('y', height / 2)
+      .attr('fill', 'white')
+      .style('font', `bold ${height * 0.8}px monospace`)
+      .merge(featureText)
+      .text(d => d);
+  };
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.color = function(_) {
+    if (!arguments.length) return color;
+    color = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {featureChart};

--- a/projects/location_layer/visualizations/js/src/charts/layerOfCellsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/layerOfCellsChart.js
@@ -1,0 +1,201 @@
+import * as d3 from "d3";
+
+/**
+ * Example params:
+ * {
+ *   dimensions: {rows: 5, cols: 5},
+ *   cells: [{cell: 42, state: 'active'},
+ *           {cell: 43, state: 'predicted'},
+ *           {cell: 44, state: 'predicted-active'}]
+ *   highlightedCells: [42]
+ * }
+ */
+function layerOfCellsChart() {
+  let width,
+      height,
+      color = d3.scaleOrdinal()
+        .domain(['active', 'predicted', 'predicted-active'])
+        .range(['crimson', 'rgba(0, 127, 255, 0.498)', 'black']),
+      stroke = "black",
+      onCellSelected = selectedCell => {},
+      columnMajorIndexing = false;
+
+  let drawHighlightedCells = function(selection) {
+    selection.each(function(layerData) {
+      d3.select(this).selectAll('.cell')
+        .attr('stroke-width', d =>
+              layerData.highlightedCells.indexOf(d.cell) != -1
+              ? 2
+              : 0);
+    });
+  };
+
+  let chart = function(selection) {
+    selection.each(function(layerData) {
+      let layerNode = this,
+          layer = d3.select(layerNode),
+          xScale = d3.scaleLinear()
+            .domain([0, layerData.dimensions.cols - 1])
+            .range([5, width - 5]),
+          yScale = d3.scaleLinear()
+            .domain([0, layerData.dimensions.rows - 1])
+            .range([5, height - 5]);
+
+      let x, y;
+      if (columnMajorIndexing) {
+        x = d => xScale(Math.floor(d.cell / layerData.dimensions.rows));
+        y = d => yScale(d.cell % layerData.dimensions.rows);
+      } else {
+        x = d => xScale(d.cell % layerData.dimensions.cols);
+        y = d => yScale(Math.floor(d.cell / layerData.dimensions.cols));
+      }
+
+      // For each layer, keep:
+      // - the selected cell, so that we fire events only when the selection
+      //   changes.
+      // - the mouse position from the most recent mousemove, so that we can
+      //   reevaluate the selected cell when the data changes.
+      if (layerNode._selectedCell === undefined) {
+        layerNode._selectedCell = null;
+      }
+      if (layerNode._mousePosition === undefined) {
+        layerNode._mousePosition = null;
+      }
+
+      layer.selectAll('.border')
+        .data([null])
+        .enter().append('rect')
+          .attr('class', 'border')
+          .attr('stroke', stroke)
+          .attr('stroke-width', 1)
+          .attr('fill', 'none')
+          .attr('width', width)
+          .attr('height', height);
+
+      let cells = layer.selectAll('.cells')
+          .data([layerData.cells]);
+
+      cells = cells.enter()
+        .append('g')
+          .attr('class', 'cells')
+        .merge(cells);
+
+      let cell = cells.selectAll('.cell')
+          .data(d => d);
+
+      cell.exit().remove();
+
+      cell = cell.enter()
+        .append('polygon')
+          .attr('class', 'cell')
+          .attr('stroke', 'goldenrod')
+        .merge(cell)
+          .attr('fill', d => color(d.state))
+          .attr('stroke-width', d =>
+                layerData.highlightedCells.indexOf(d.cell) != -1
+                ? 2
+                : 0);
+
+      // Enable fast lookup of the cell nearest to the cursor.
+      let quadtree = d3.quadtree()
+          .extent([[0, 0], [width, height]])
+          .x(x)
+          .y(y)
+          .addAll(layerData.cells);
+
+      let mouseEvents = layer.selectAll('.mouseEvents')
+          .data([null]);
+
+      mouseEvents.enter()
+        .append('rect')
+          .attr('class', 'mouseEvents')
+          .attr('stroke', 'transparent')
+          .attr('fill', 'transparent')
+          .attr('width', width)
+          .attr('height', height)
+        .merge(mouseEvents)
+        .on('mousemove', function() {
+          layerNode._mousePosition = d3.mouse(this);
+
+          let p = quadtree.find(layerNode._mousePosition[0],
+                                layerNode._mousePosition[1]);
+
+          if (p !== layerNode._selectedCell) {
+            layerNode._selectedCell = p;
+            draw();
+            onCellSelected(p.cell);
+          }
+        })
+        .on('mouseleave', () => {
+          layerNode._mousePosition = null;
+
+          if (layerNode._selectedCell !== null) {
+            layerNode._selectedCell = null;
+            draw();
+            onCellSelected(null);
+          }
+        });
+
+      // If we're rerendering, check if it has caused the nearest cell to
+      // change.
+      if (layerNode._mousePosition !== null) {
+        let p = quadtree.find(layerNode._mousePosition[0],
+                              layerNode._mousePosition[1]);
+        if (p !== layerNode._selectedCell) {
+          layerNode._selectedCell = p;
+          onCellSelected(p.cell);
+        }
+      }
+
+      draw();
+
+
+      function draw() {
+        cell
+          .attr('transform', d => `translate(${x(d)},${y(d)})`)
+          .attr('points', cell =>
+                cell == layerNode._selectedCell
+                ? '0,-6 5,6 -5,6'
+                : (cell.state == 'predicted')
+                ? '0,-3 1.5,1.5 -1.5,1.5'
+                : '0,-4 2,2 -2,2');
+      }
+    });
+  };
+
+  chart.drawHighlightedCells = drawHighlightedCells;
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.stroke = function(_) {
+    if (!arguments.length) return stroke;
+    stroke = _;
+    return chart;
+  };
+
+  chart.onCellSelected = function(_) {
+    if (!arguments.length) return onCellSelected;
+    onCellSelected = _;
+    return chart;
+  };
+
+  chart.columnMajorIndexing = function(_) {
+    if (!arguments.length) return columnMajorIndexing;
+    columnMajorIndexing = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {layerOfCellsChart};

--- a/projects/location_layer/visualizations/js/src/charts/layerOfCellsChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/layerOfCellsChart.js
@@ -15,7 +15,7 @@ function layerOfCellsChart() {
       height,
       color = d3.scaleOrdinal()
         .domain(['active', 'predicted', 'predicted-active'])
-        .range(['crimson', 'rgba(0, 127, 255, 0.498)', 'black']),
+        .range(['orangered', 'rgba(0, 127, 255, 0.498)', 'black']),
       stroke = "black",
       onCellSelected = selectedCell => {},
       columnMajorIndexing = false;

--- a/projects/location_layer/visualizations/js/src/charts/locationModulesChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/locationModulesChart.js
@@ -1,0 +1,132 @@
+import * as d3 from 'd3';
+import {layerOfCellsChart} from './layerOfCellsChart.js';
+
+/**
+ * Data:
+ * {modules: [{dimensions: {rows: 5, cols: 5},
+ *             scale: 3.2,
+ *             orientation: 0.834,
+ *             cells: [{cell: 2, state: 'active'}],
+ *            ...],
+ *  highlightedCells: [10, 46]}
+ */
+function locationModulesChart() {
+  var width,
+      height,
+      onCellSelected = (iModule, selectedCell) => {};
+
+  let drawHighlightedCells = function(selection) {
+    selection.each(function(moduleArrayData) {
+      let moduleWidth = width / 6,
+          moduleHeight = height / 3,
+          highlightedCellsByModule = [];
+
+      let base = 0;
+      moduleArrayData.modules.forEach(module => {
+        let end = base + module.dimensions.rows*module.dimensions.cols;
+
+        let highlightedInModule = [];
+        moduleArrayData.highlightedCells.forEach(cell => {
+          if (cell >= base && cell < end) {
+            highlightedInModule.push(cell - base);
+          }
+        });
+
+        highlightedCellsByModule.push(highlightedInModule);
+
+        base = end;
+      });
+
+      let module = d3.select(this)
+          .selectAll('.module')
+          .datum((d, i) => {
+            d.highlightedCells = highlightedCellsByModule[i];
+            return d;
+          })
+          .each(function(d, i) {
+            d3.select(this).call(
+              layerOfCellsChart()
+                .width(moduleWidth)
+                .height(moduleHeight)
+                .stroke('lightgray')
+                .onCellSelected(
+                  cell => onCellSelected(cell !== null ? i : null,
+                                         cell))
+                .drawHighlightedCells);
+          });
+    });
+  };
+
+  var chart = function(selection) {
+    let modules = selection.selectAll('.modules')
+        .data(d => [d]);
+
+    modules = modules.enter()
+      .append('g')
+      .attr('class', 'modules')
+      .merge(modules);
+
+    selection.selectAll('.boundary')
+      .data([null])
+      .enter().append('rect')
+      .attr('class', 'boundary')
+      .attr('fill', 'none')
+      .attr('stroke', 'black')
+      .attr('width', width)
+      .attr('height', height);
+
+    modules.each(function(moduleArrayData) {
+      // TODO: stop hardcoding 18 modules
+      let moduleWidth = width / 6,
+          moduleHeight = height / 3;
+
+      let module = d3.select(this)
+          .selectAll('.module')
+          .data(moduleArrayData.modules.map(m => {
+            return Object.assign({highlightedCells: []}, m);
+          }));
+
+      module.exit().remove();
+
+      module = module.enter().append('g')
+        .attr('class', 'module')
+        .merge(module)
+        .attr('transform',
+              (d, i) => `translate(${Math.floor(i/3) * moduleWidth},${(i%3)*moduleHeight})`)
+        .each(function(d, i) {
+          d3.select(this)
+            .call(layerOfCellsChart()
+                  .width(moduleWidth)
+                  .height(moduleHeight)
+                  .stroke('lightgray')
+                  .onCellSelected(
+                    cell => onCellSelected(cell !== null ? i : null,
+                                           cell)));
+        });
+    });
+  };
+
+  chart.drawHighlightedCells = drawHighlightedCells;
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.onCellSelected = function(_) {
+    if (!arguments.length) return onCellSelected;
+    onCellSelected = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {locationModulesChart};

--- a/projects/location_layer/visualizations/js/src/charts/motionChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/motionChart.js
@@ -1,0 +1,162 @@
+import * as d3 from 'd3';
+import {arrowShape} from './../shapes/arrowShape.js';
+
+function motionChart() {
+  let chart = function(selection) {
+    selection.each(function(deltaLocation) {
+      let data = deltaLocation != null ? [deltaLocation] : [];
+
+      let arrow = d3.select(this).selectAll('.arrow')
+          .data(data);
+
+      arrow.exit().remove();
+
+      let arrowLength,
+          correctedArrowLength,
+          correctionFactor;
+      if (deltaLocation != null) {
+        arrowLength = Math.sqrt(Math.pow(deltaLocation.top, 2) +
+                                Math.pow(deltaLocation.left, 2));
+        correctedArrowLength = Math.min(900, Math.max(15, arrowLength));
+        correctionFactor = correctedArrowLength / arrowLength;
+      }
+
+      arrow.enter().append('g')
+          .attr('class', 'arrow')
+          .call(enter => {
+            enter.append('path');
+          })
+        .merge(arrow)
+          .attr('transform', d => {
+            let radians = Math.atan(d.top / d.left),
+                degrees = radians * 180 / Math.PI;
+            if (d.left < 0) {
+              degrees += 180;
+            }
+            return `rotate(${degrees})`;
+          })
+        .select('path')
+        .attr('d', d => arrowShape()
+            .arrowLength(correctedArrowLength)
+            .arrowWidth(3)
+            .markerLength(10)
+            .markerWidth(8)());
+
+      let leftLabel = d3.select(this).selectAll('.leftLabel')
+          .data(deltaLocation == null || deltaLocation.left == 0
+                ? []
+                : [deltaLocation]);
+
+      leftLabel.exit().remove();
+
+      leftLabel = leftLabel.enter().append('g')
+          .attr('class', 'leftLabel')
+          .call(enter => {
+            enter.append('line')
+              .attr('class', 'line')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1);
+
+            let r = 2;
+
+            enter.append('line')
+              .attr('class', 'beginCap')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1)
+              .attr('y1', -r)
+              .attr('y2', r);
+
+            enter.append('line')
+              .attr('class', 'endCap')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1)
+              .attr('y1', -r)
+              .attr('y2', r);
+
+            enter.append('text')
+              .attr('text-anchor', 'middle')
+              .attr('dy', 12)
+              .style('font', '10px Verdana');
+          })
+        .merge(leftLabel)
+        .attr('transform', d => {
+          return `translate(0,${Math.abs(d.top/2) + 10})`;
+        });
+
+      leftLabel.select('text')
+        .text(d => d3.format('.0f')(Math.abs(d.left)));
+
+      leftLabel.select('.beginCap')
+        .attr('x1', d => -correctionFactor*d.left/2)
+        .attr('x2', d => -correctionFactor*d.left/2);
+
+      leftLabel.select('.endCap')
+        .attr('x1', d => correctionFactor*d.left/2)
+        .attr('x2', d => correctionFactor*d.left/2);
+
+      leftLabel.select('.line')
+        .attr('x1', d => -correctionFactor*d.left/2)
+        .attr('x2', d => correctionFactor*d.left/2);
+
+      let topLabel = d3.select(this).selectAll('.topLabel')
+          .data(deltaLocation == null || deltaLocation.top == 0
+                ? []
+                : [deltaLocation]);
+
+      topLabel.exit().remove();
+
+      topLabel = topLabel.enter().append('g')
+          .attr('class', 'topLabel')
+          .call(enter => {
+            enter.append('line')
+              .attr('class', 'line')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1);
+
+            let r = 2;
+
+            enter.append('line')
+              .attr('class', 'beginCap')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1)
+              .attr('x1', -r)
+              .attr('x2', r);
+
+            enter.append('line')
+              .attr('class', 'endCap')
+              .attr('stroke', 'gray')
+              .attr('stroke-width', 1)
+              .attr('x1', -r)
+              .attr('x2', r);
+
+            enter.append('text')
+              .attr('dx', 4)
+              .attr('dy', 4)
+              .style('font', '10px Verdana');
+          })
+        .merge(topLabel)
+        .attr('transform', d => {
+          return `translate(${Math.abs(d.left/2) + 12},0)`;
+        });
+
+      topLabel.select('text')
+        .text(d => d3.format('.0f')(Math.abs(d.top)));
+
+      topLabel.select('.beginCap')
+        .attr('y1', d => -correctionFactor*d.top/2)
+        .attr('y2', d => -correctionFactor*d.top/2);
+
+      topLabel.select('.endCap')
+        .attr('y1', d => correctionFactor*d.top/2)
+        .attr('y2', d => correctionFactor*d.top/2);
+
+      topLabel.select('.line')
+        .attr('y1', d => -correctionFactor*d.top/2)
+        .attr('y2', d => correctionFactor*d.top/2);
+    });
+  };
+
+  return chart;
+};
+
+export {motionChart};

--- a/projects/location_layer/visualizations/js/src/charts/timelineChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/timelineChart.js
@@ -1,0 +1,248 @@
+import * as d3 from 'd3';
+import {arrowShape} from './../shapes/arrowShape.js';
+
+/**
+ * Data example:
+ * [{timesteps: [{}, {}, {reset: true}, {}, {}]
+ *   selectedIndex: 2},
+ *  ...]
+ *
+ * "reset: true" implies that a reset happened before that timestep.
+ */
+function timelineChart() {
+  var onchange,
+      senseWidth = 16,
+      moveWidth = 16,
+      resetWidth = 6,
+      repeatOffset = 10,
+      betweenRepeatOffset = 6;
+
+  let drawSelectedStep = function(selection) {
+    selection.each(function(timelineData) {
+      d3.select(this).selectAll('.colorWithSelection')
+        .attr('fill', d => d.iTimestep == timelineData.selectedIndex
+              ? 'black'
+              : 'lightgray');
+
+      d3.select(this).selectAll('.move.colorWithSelection')
+        .attr('stroke', d => d.iTimestep == timelineData.selectedIndex
+              ? 'black'
+              : 'lightgray');
+
+      d3.select(this).selectAll('.selectedText')
+        .style('visibility', d => d.iTimestep == timelineData.selectedIndex
+               ? 'visible'
+               : 'hidden');
+    });
+  };
+
+  var chart = function(selection) {
+    let timeline = selection.selectAll('.timeline')
+        .data(d => [d]);
+
+    timeline = timeline.enter()
+      .append('g')
+      .attr('class', 'timeline')
+      .merge(timeline);
+
+    timeline.each(function(timelineData) {
+      let timelineNode = d3.select(this);
+
+      let shapes = [];
+
+      let touchNumber = 0;
+
+
+      timelineData.timesteps.forEach((timestep, iTimestep) => {
+
+        if (timestep.reset && iTimestep !== 0) {
+          shapes.push({type: 'reset'});
+          touchNumber = 0;
+        }
+
+        let o = Object.assign({iTimestep}, timestep);
+
+        switch (o.type) {
+        case 'sense':
+          touchNumber++;
+
+          o.text = `Touch ${touchNumber}`;
+
+          shapes.push({
+            type: 'sense',
+            timesteps: [o]
+          });
+
+          break;
+        case 'move':
+          o.text = 'Move';
+          shapes.push(o);
+          break;
+        case 'repeat': {
+          let touchData = shapes[shapes.length-1];
+
+          if (touchData.type != 'sense') {
+            throw `Invalid data ${touchData.type}`;
+          }
+
+          o.text = 'Settle';
+          touchData.timesteps.push(o);
+          break;
+        }
+        default:
+          throw `Unrecognized ${o.type}`;
+        }
+      });
+
+      let onchangeFn = onchange
+          ? d => onchange(d.iTimestep)
+          : null;
+
+      let verticalElement = timelineNode.selectAll('.verticalElement')
+          .data(shapes);
+
+      verticalElement.exit().remove();
+
+      // Clean up updating nodes.
+      // shape.filter(d => d.type == 'reset')
+      //   .selectAll(':scope > :not(.reset)')
+      //   .remove();
+      // shape.filter(d => d.type == 'move')
+      //   .selectAll(':scope > :not(.move)')
+      //   .remove();
+      // shape.filter(d => d.type == 'sense')
+      //   .selectAll(':scope > :not(.sense)')
+      //   .remove();
+
+      verticalElement = verticalElement.enter()
+        .append('div')
+        .attr('class', 'shape')
+        .style('position', 'relative')
+        .style('display', 'inline-block')
+        .style('margin-top', '15px')
+        .call(enter => {
+          enter.append('svg')
+            .attr('height', 30);
+        })
+        .merge(verticalElement);
+
+      verticalElement.filter(d => d.type == 'reset')
+          .style('width', `${resetWidth}px`)
+          .style('top', '-2px')
+          .select('svg')
+        .attr('width', resetWidth)
+        .selectAll('.reset')
+        .data([null])
+        .enter().append('rect')
+          .attr('class', 'reset')
+          .attr('height', 15)
+          .attr('width', 2)
+        .attr('fill', 'gray');
+
+
+      let move = verticalElement.filter(d => d.type == 'move')
+          .style('width', `${moveWidth}px`)
+          .call(m => {
+            let selectedText = m.selectAll('.selectedText')
+                .data(d => [d]);
+
+            selectedText.enter().append('div')
+              .attr('class', 'selectedText')
+              .style('position', 'absolute')
+              .style('width', '50px')
+              .style('left', '-18px')
+              .style('top', '-16px')
+              .style('font', '10px Verdana')
+              .merge(selectedText)
+              .text(d => d.text);
+          })
+          .select('svg')
+          .attr('width', moveWidth)
+          .selectAll('.move')
+          .data(d => [d]);
+
+      move.enter()
+        .append('g')
+          .attr('class', 'move colorWithSelection')
+          .attr('cursor', onchange ? 'pointer' : null)
+          .call(enter => {
+            enter.append('path')
+              .attr('d', arrowShape()
+                    .arrowLength(12)
+                    .arrowWidth(3)
+                    .markerLength(5)
+                    .markerWidth(8));
+          })
+        .merge(move)
+        .attr('transform', d => {
+          let radians = Math.atan(d.deltaLocation.top / d.deltaLocation.left),
+              degrees = radians * 180 / Math.PI;
+          if (d.deltaLocation.left < 0) {
+            degrees += 180;
+          }
+          return `translate(6, 6) rotate(${degrees})`;
+        })
+        .on('click', onchangeFn);
+
+      let sense = verticalElement.filter(d => d.type == 'sense')
+            .style('width', `${senseWidth}px`)
+          .call(s => {
+
+            let selectedText = s.selectAll('.selectedText')
+                .data(d => d.timesteps);
+
+            selectedText.exit().remove();
+
+            selectedText.enter().append('div')
+              .attr('class', 'selectedText')
+              .style('position', 'absolute')
+              .style('width', '50px')
+              .style('left', '-18px')
+              .style('top', '-16px')
+              .style('font', '10px Verdana')
+              .merge(selectedText)
+              .text(d => d.text);
+          })
+          .select('svg')
+          .attr('width', senseWidth)
+          .selectAll('.sense')
+          .data(d => [d]);
+
+      sense = sense.enter()
+        .append('g')
+          .attr('class', 'sense')
+        .merge(sense);
+
+      let repeat = sense.selectAll('.repeat')
+          .data(d => d.timesteps);
+
+      repeat.exit().remove();
+
+      repeat.enter().append('circle')
+          .attr('class', 'repeat colorWithSelection')
+          .attr('stroke', 'none')
+          .attr('r', (d, i) => i == 0 ? 6 : 2)
+          .attr('cx', 6)
+          .attr('cy', (d, i) => 6 + (i == 0
+                                     ? 0
+                                     : repeatOffset + (i-1)*betweenRepeatOffset))
+          .attr('cursor', onchange ? 'pointer' : null)
+        .merge(repeat)
+          .on('click', onchangeFn);
+    });
+
+    drawSelectedStep(selection);
+  };
+
+  chart.drawSelectedStep = drawSelectedStep;
+
+  chart.onchange = function(_) {
+    if (!arguments.length) return onchange;
+    onchange = _;
+    return chart;
+  };
+
+  return chart;
+}
+
+export {timelineChart};

--- a/projects/location_layer/visualizations/js/src/charts/worldChart.js
+++ b/projects/location_layer/visualizations/js/src/charts/worldChart.js
@@ -1,0 +1,224 @@
+import * as d3 from 'd3';
+import {featureChart} from './featureChart.js';
+
+const CURSOR_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAA1CAYAAAADOrgJAAAAAXNSR0IArs4c6QAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAnRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyI+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjMwMDwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6Q29tcHJlc3Npb24+NTwvdGlmZjpDb21wcmVzc2lvbj4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+MzAwPC90aWZmOlhSZXNvbHV0aW9uPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkZseWluZyBNZWF0IEFjb3JuIDUuNi40PC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6TW9kaWZ5RGF0ZT4yMDE3LTA2LTEyVDExOjI2OjI5PC94bXA6TW9kaWZ5RGF0ZT4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CrudzKAAAAm6SURBVGgF7ZhPbJVZGca/2z9MYaDQ4vAn40yZdmIGjaBBVxAkGiAhRFxgCLKYZFgYFuBi4gIWJi5dmIDBQGKiC2IMRsQY2Zk4akxQF0BYGFkACs0EbCkpLbbQe795fqff891zv/vd9t6CE2N8k6fv+fOec97nfc8537lNkv/Lf1cEKi/ZnbL50pe8Rul0ZQuXGi7Q2Mkc/zFSnThRxsXjizq2tfPW9MXl2HbJZTuwlAk8Fg26Mu125sThMrgP/VIkXrSTCT3OzqNBj9AtuL+m8nMBbZiYml5eZli0U7GTReeXaSKcnRWqAgTQrwiM8bh4W7lN3S8mRLAT8cJ2jECAV4VnwteFrwmTwgrhvvB9AXIAGwSCSExqvuVj+gsBbyEiDYFBYUBAzgjeOugPhdeE5cJaoV/oE3oF5nFAVHwx6TQjXs2E2E7IV4U3du3a9Znt27cnjx8/frpixYq+qamp6rlz576lvinhkvBQgITJshUpMx/6YxFHj61ENlYK6wWy8UchPX/+fCqp8ScTtpCd3pHZkkG2HYSYK84MayxJOs2IyaBxgvE48m8hGRsbm5PK53z27BkRx/apgOMEAGK+yVTMiZZlpKyNMU2SL9rU07oBx3AeQMaEEmWBvlyyuklDApAlSCH0Fa9l2pxFz7cooaUQsQMmwmJhwVoNn+oS1ennkHPoIYKhx7tOW7wVTQa9KKF2iXgitOGsoEO/MqBiXQp11gLYkhEc9wB0GTHaYzDWY1SsSztEgpMagi7CZGxTn1mlAhGu3w0CBDgzfFM4K5wrMsF3htuNcgwTtmatJjILEYmdo2yny7S6myU7IyzK2fiegNOIo0yZtlXCH4T3BGxNkD4TVTHPYhOZVkRMAm0S6PhwM5Y6xGyvYl2iM0Lj6npPaelNtXpOok9W2ILM7+eOiuVkMCqKnTIBO8/Hj8PKNwDtLzSLe4yKpZJev379+YMHD+Zu3bo1Nzs7O3fgwAGcQ64K3xR+K/xG+LnwK+HXwjsCZFjPJEsDR2csdigmwUAmYzs8ESDkCPHkaEkkPiNbt24NduvWrdOQJBkaGiLiyLjwgcCH8nNCLIyZFFjHPnhbovETHZxAxxKTIBtEHvm0cEzAARYAvxDuCyzSJHNzbO/6YrGBnjGukuEhYQ0NK1eufH7x4sWu7u7u2uHDh789MTHBxfAj4c8C67DtQE5C5QYidCAmQiaIPvUJgVB+Q4iF7fB3IUQl7qD89Ck+zPdVq9VEzlEPcv8+/IMQGG6skCG9zyr79u1j7a7+/v79IoLR7wS2oHcD/ayZr0tUY8FpE2EQk39B+PLGjRs/eezYsVQLEeau3t7e5MyZM/tU/7zqrwuJMsACuaxdu7ais1BRlNOYBAZHjx7tWrVqVbJ58+bhbdu2vXv37t23b9y4kYyMjDAHPtQUCK5objEEXXa5YJsTwpAGDEkf6f6EwCH7jpDu3LlTW77hQVgbHBx0VNC1U6dOYdOJxA9MxsX16sDAAGeRuY8LfIMImH8KkASTDgXVAwk0AiGAEVkJP4YU+bBPVM9F5OY2bdpUrVQqLFYpXLe53QIFR5PMe9/n5tF8BNjZyJ3PDVWgsSgxEcqQYX/70Nu+cvny5Z47d+507927FzufCfe3qxlrJxvGKEOu4yc29s3tuS4jkneqQD9PdLLCqfONoWJd1qxZE7ZWttXqHSo9efKEvZ57pHOUTk5OMo/bQp32hoGNFRMIAVOX641WUQesyQA/YXkbvSFwmHcIJwUWe17Yy97b7O94j6e6mdgyAe7TYeayqF24cIFx6enTp5mztmXLloax6qrq1vIZeV82Qxn4IccZ5iwT6EDOtxaT0YA27MS02gAfJoTBRDSfRGVHSsW6ZDcVdswZRNlpiGZ2DirZVW2zoLu6GBrEPrWqB2fcac0gHIUIEWFbkSW+Fzwlvrthw4aZ1atXV3THY9NSuKIlOQkqXLnI8uVciHXt9tA4/6ciIh7rLV0klJs7I26wYUyEjxUejQk8J0b0ZpIK342gW/3JIupMBzPdcKU6ir6nS/UPjN5Hjx5RJzVsSba+fVSxLjERDLyoiTCYjHDgITMfxvlJk76+PsYsSYqEdCY8T23//v2JslnTGfuxGkeFmwLr4wu+mUw+KCai/iB0YgwpiBANIgEZthI6PMm1HfJNrLYmyZzLF8PADhe1ifGUuXLlCvOy/u+Fvwqus9VNRMUgYf6iI17UZHDcWWGLERFy/UPhp8ePH5/QsyW5ffs2kzdJ5iwONUn0sQt9fsJIs7bX5WxyQ9EGCdpNxL6qqfHRGBr0BwMWRwNPChEyA5EfCANnz57dLZ0cOXKka3h42ONoCjI9zWXXKPfu3QsNfv1mj8JE3xYbOvqsReCYBBIxkabAYVwmcRRdRgPG8J3xv0vH9Ezpe/jw4avsaz0U8yxza127di3VozA9ePBgGK8s1SBIJtevX1/p6elJRS7dvXs3znVdvXp1+tKlS39S+W/CB8K/BAgRSJNxkNW0uMSOO8X8ZuDxNixsEb4obBP+IqQnT56Un0uT7OOJgx8KewV+ZH1WeEt4TeDe5gXMuXbWVJyXPHpuiDSTImiixRYjIkRnRuARSR8T/0O4p5+wYzMzM4m2S1Pq1d8gPF1u3rxZ1Zhgq0ep+wkgNxTB8/lEtzwf6ltUnBUI4zAPR/7ny/PldeFTAk+YLwk7hJ8J6Z49e+YWy8uhQ4cIQnrixIlgOjo6CiHayMhXBLIxIvCDrl9omQ31NfxCpF4UJoZMWFSaqCAmaE0EiRpIli1bhv1CWanIhqzO6pbCwb7x8XHmJliM8w3JDnA27AN6yWKHOeg4TWaIEnv3TYHovSP8RGAhHMChMuAYNmTvoPDL7CnClqV9VODsvSVsFPhm8SEuPRtqD0JnO8ICkEHjHIKzJsh+JsK0IU2Hcb45/CUYCPftP4Wp7JsSn1dnxNlgTdYGpYIj7Ypt7byzAwkyhB7KQB91dEzKGWIOHmzjwqDA0xzn6YcgV++0YEIEiK3Xkoydk01bYns0DpqMtxsZpg1itMXbwU6YjEn6G0E7ZWe1SIJ+z6Fio7S7tTyKiSDhCZk8HPDMgIMLQbfRb/KYMM4O+TqlHXE7ZUg4C25nbEvplAgTxWRYxGIncYBoO+JFIti1AvNBMIZt1RzGoZtkKUSYhMktJkObHfG5QBfFjnmOWHsO5gGu26Y4V16Po5U3tlnwWHQRJsJUtoudcdnaS1IvA/1FW48J2os0NHZQice7jHaZqeJy0ZliHXu3WcdtlEslXqTUoM3G4jzF+kLTxA6X2S3WH8Z0smDZImVtLzpnW46XLfw/0fYRMvJsGfpXau0AAAAASUVORK5CYII=';
+
+/**
+ * Data:
+ * {location: [12.0, 16.0],
+ *  features: [{name: 'A', location: {}, width: 12.2, height: 7.2}],
+ *  selectedLocationCell: 42,
+ *  selectedLocationModule: {
+ *    cellDimensions: [5, 5],
+ *    moduleMapDimensions: [20.0, 20.0],
+ *    orientation: 0.834
+ *    activeCells: [42],
+ *    activePoints: [[11.0, 12.0]]
+ *  }}
+ */
+function worldChart() {
+  var width,
+      height,
+      color,
+      t = 0;
+
+  let drawFiringFields = function(selection) {
+    selection.each(function(worldData) {
+      let worldBackground = d3.select(this).select('.worldBackground'),
+          firingFields = worldBackground.select('.firingFields');
+
+      let xScale = d3.scaleLinear()
+            .domain([0, worldData.dims.width])
+            .range([0, width]),
+          x = location => xScale(location.left),
+          yScale =  d3.scaleLinear()
+            .domain([0, worldData.dims.height])
+            .range([0, height]),
+          y = location => yScale(location.top);
+
+      let pattern = worldBackground.select('.myDefs')
+          .selectAll('pattern')
+          .data(worldData.selectedLocationModule
+                ? [worldData.selectedLocationModule.activePoints]
+                : []);
+
+      pattern.exit().remove();
+
+      if (worldData.selectedLocationModule) {
+        let config = worldData.selectedLocationModule,
+            distancePerCell = [config.moduleMapDimensions[0] / config.cellDimensions[0],
+                               config.moduleMapDimensions[1] / config.cellDimensions[1]],
+            pixelsPerCell = [height * (distancePerCell[0] / worldData.dims.height),
+                             width * (distancePerCell[1] / worldData.dims.width)];
+
+        pattern.enter().append('pattern')
+          .attr('id', 'FiringField')
+          .attr('patternUnits', 'userSpaceOnUse')
+          .call(enter => {
+            enter.append('path')
+              .attr('fill', 'black')
+              .attr('fill-opacity', 0.6)
+              .attr('stroke', 'none');
+          })
+          .merge(pattern)
+          .attr('width', config.cellDimensions[1])
+          .attr('height', config.cellDimensions[0])
+          .call(p => {
+            p.select('path')
+              .attr('d', points => {
+
+                let squares = [];
+
+                for (let i = -1; i < 2; i++) {
+                  for (let j = -1; j < 2; j++) {
+                    points.forEach(point => {
+
+                      let cellFieldOrigin = [
+                        Math.floor(worldData.selectedLocationCell / config.cellDimensions[1]),
+                        worldData.selectedLocationCell % config.cellDimensions[1]];
+
+                      let top = i*config.cellDimensions[1] + (cellFieldOrigin[0] - point[0]),
+                          left = j*config.cellDimensions[0] + (cellFieldOrigin[1] - point[1]);
+
+                      squares.push(`M ${left} ${top} l 1 0 l 0 1 l -1 0 Z`);
+
+                    });
+                  }
+                }
+
+                return squares.join(' ');
+              });
+          })
+          .attr('patternTransform', point => {
+            let translateLocation = {
+              top: worldData.location.top,
+              left: worldData.location.left
+            };
+
+            return `translate(${x(translateLocation)},${y(translateLocation)}) `
+              + `rotate(${180 * config.orientation / Math.PI}, 0, 0) `
+              + `scale(${pixelsPerCell[1]},${pixelsPerCell[0]})`;
+          });
+      }
+
+      let firingField = firingFields.selectAll('.firingField')
+          .data(worldData.selectedLocationModule
+                ? [worldData.selectedLocationModule.activePoints]
+                : []);
+
+      firingField.enter().append('rect')
+        .attr('class', 'firingField')
+        .attr('fill', (d,i) => `url(#FiringField)`)
+        .attr('stroke', 'none')
+        .attr('width', width)
+        .attr('height', height);
+
+      firingField.exit().remove();
+    });
+  };
+
+  var chart = function(selection) {
+    selection.each(function(worldData) {
+      let worldNode = d3.select(this);
+
+      let xScale = d3.scaleLinear()
+            .domain([0, worldData.dims.width])
+            .range([0, width]),
+          x = location => xScale(location.left),
+          yScale =  d3.scaleLinear()
+            .domain([0, worldData.dims.height])
+            .range([0, height]),
+          y = location => yScale(location.top);
+
+
+      let features = worldNode.selectAll('.features')
+        .data(d => [d]);
+
+      features = features.enter().append('g')
+        .attr('class', 'features')
+        .merge(features);
+
+      let feature = features.selectAll('feature')
+          .data(d => d.features ? d.features : []);
+
+      feature.exit().remove();
+
+      feature.enter()
+        .append('g')
+        .attr('class', 'feature')
+        .merge(feature)
+        .attr('transform', d => `translate(${x(d)},${y(d)})`)
+        .each(function(featureData) {
+          d3.select(this)
+            .call(featureChart()
+                  .width(xScale(featureData.width))
+                  .height(yScale(featureData.height))
+                  .color(color));
+        });
+
+      let worldBackground = worldNode.selectAll('.worldBackground')
+        .data(d => [d]);
+
+      worldBackground = worldBackground
+        .enter().append('g')
+          .attr('class', 'worldBackground')
+        .call(enter => {
+          enter.append('defs')
+              .attr('class', 'myDefs');
+
+          enter.append('rect').attr('fill', 'none')
+            .attr('width', width)
+            .attr('height', height)
+            .attr('stroke', 'lightgray')
+            .attr('stroke-width', 1);
+
+          enter.append('g').attr('class', 'firingFields');
+
+        })
+        .merge(worldBackground);
+
+      let currentLocation = d3.select(this).selectAll('.currentLocation')
+          .data([null]);
+
+      currentLocation.enter().append('g')
+        .attr('class', 'currentLocation')
+        .call(enter => {
+          enter.append('image')
+            .attr('x', -21)
+            .attr('y', -10)
+            .attr('width', 50)
+            .attr('height', 53)
+            .attr('xlink:href', CURSOR_URL);
+        })
+        .merge(currentLocation)
+        .attr('transform', `translate(${x(worldData.location)},${y(worldData.location)})`);
+    });
+
+    drawFiringFields(selection);
+  };
+
+  chart.drawFiringFields = drawFiringFields;
+
+  chart.width = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return chart;
+  };
+
+  chart.height = function(_) {
+    if (!arguments.length) return height;
+    height = _;
+    return chart;
+  };
+
+  chart.color = function(_) {
+    if (!arguments.length) return color;
+    color = _;
+    return chart;
+  };
+
+
+  return chart;
+}
+
+export {worldChart};

--- a/projects/location_layer/visualizations/js/src/locationModuleInference.js
+++ b/projects/location_layer/visualizations/js/src/locationModuleInference.js
@@ -1,0 +1,842 @@
+import * as d3 from 'd3';
+import {arrayOfAxonsChart} from './charts/arrayOfAxonsChart.js';
+import {decodedLocationsChart} from './charts/decodedLocationsChart.js';
+import {decodedObjectsChart} from './charts/decodedObjectsChart.js';
+import {featureChart} from './charts/featureChart.js';
+import {layerOfCellsChart} from './charts/layerOfCellsChart.js';
+import {locationModulesChart} from './charts/locationModulesChart.js';
+import {motionChart} from './charts/motionChart.js';
+import {timelineChart} from './charts/timelineChart.js';
+import {worldChart} from './charts/worldChart.js';
+
+/**
+ *
+ * Example timestep:
+ * {
+ *   worldLocation: {left: 42.0, top: 12.0},
+ *   reset: null,
+ *   locationLayer: {
+ *     modules: [
+ *       {activeCells: [],
+ *        activePoints: [],
+ *        activeSynapsesByCell: {}},
+ *     ]
+ *   },
+ *   inputLayer: {
+ *     activeCells: [],
+ *     decodings: [],
+ *     activeSynapsesByCell: {
+ *       42: {
+ *         locationLayer: [12, 17, 29],
+ *         objectLayer: [42, 45]
+ *       }
+ *     }
+ *   },
+ *   objectLayer: {
+ *     activeCells: [],
+ *     decodings: [],
+ *     activeSynapsesByCell: {}
+ *   },
+ *   deltaLocationInput: {
+ *   },
+ *   featureInput: {
+ *     inputSize: 150,
+ *     activeBits: [],
+ *     decodings: []
+ *   }
+ * };
+ */
+function parseData(text) {
+  let featureColor = d3.scaleOrdinal(),
+      timesteps = [],
+      rows = text.split('\n');
+
+  // Row: world dimensions
+  let worldDims = JSON.parse(rows[0]);
+
+  // Row: Features and colors
+  //   {'A': 'red',
+  //    'B': 'blue',
+  //    'C': 'gray'}
+  let featureColorMapping = JSON.parse(rows[1]);
+
+  var features = [],
+      colors = [];
+
+  for (var feature in featureColorMapping) {
+    features.push(feature);
+    colors.push(featureColorMapping[feature]);
+  }
+
+  featureColor
+    .domain(features)
+    .range(colors);
+
+  // Third row: Objects
+  // {
+  //   'Object 1': [
+  //     {top: 12.0, left: 11.2, width: 5.2, height: 19, name: 'A'},
+  //     ...
+  //   ],
+  //   'Object 2': []
+  // };
+  let objects = JSON.parse(rows[2]);
+
+  let currentTimestep = null,
+      didReset = false,
+      objectPlacements = null,
+      worldFeatures = null,
+      locationInWorld = null;
+
+  // [{cellDimensions: [5,5], moduleMapDimensions: [20.0, 20.0], orientation: 0.2},
+  //  ...]
+  let configByModule = JSON.parse(rows[3]).map(d => {
+    d.dimensions = {rows: d.cellDimensions[0], cols: d.cellDimensions[1]};
+    return d;
+  });
+
+  function endTimestep() {
+    if (currentTimestep !== null) {
+      currentTimestep.objectPlacements = objectPlacements;
+      currentTimestep.worldFeatures = worldFeatures;
+
+      if (currentTimestep.type == 'move') {
+        currentTimestep.worldLocation = locationInWorld;
+        currentTimestep.featureInput = {
+          inputSize: 150,
+          activeBits: [],
+          decodings: []
+        };
+
+        // Continue showing the previous object layer.
+        for (let i = timesteps.length - 1; i >= 0; i--) {
+          if (timesteps[i].type !== 'move') {
+            currentTimestep.objectLayer =
+              Object.assign({}, timesteps[i].objectLayer);
+            currentTimestep.objectLayer.activeSynapsesByCell = {};
+            break;
+          }
+        }
+      }
+
+      timesteps.push(currentTimestep);
+    }
+
+    currentTimestep = null;
+  }
+
+  function beginNewTimestep(type) {
+    endTimestep();
+
+    currentTimestep = {
+      worldLocation: locationInWorld,
+      type
+    };
+
+    if (didReset) {
+      currentTimestep.reset = true;
+      didReset = false;
+    }
+  }
+
+  let i = 4;
+  while (i < rows.length) {
+    switch (rows[i]) {
+    case 'reset':
+      didReset = true;
+      i++;
+      break;
+    case 'sense':
+      beginNewTimestep('sense');
+
+      currentTimestep.featureInput = {
+        inputSize: 150,
+        activeBits: JSON.parse(rows[i+1]),
+        decodings: JSON.parse(rows[i+2])
+      };
+
+      i += 3;
+      break;
+    case 'sensoryRepetition':
+      beginNewTimestep('repeat');
+      currentTimestep.featureInput = timesteps[timesteps.length - 1].featureInput;
+      i++;
+      break;
+    case 'move': {
+      beginNewTimestep('move');
+      let deltaLocation = JSON.parse(rows[i+1]);
+
+      currentTimestep.deltaLocation = {
+        top: deltaLocation[0],
+        left: deltaLocation[1]
+      };
+
+      i += 2;
+      break;
+    }
+    case 'locationInWorld': {
+      let location = JSON.parse(rows[i+1]);
+
+      locationInWorld = {top: location[0], left: location[1]};
+
+      i += 2;
+      break;
+    }
+    case 'shift': {
+      let modules = [];
+      JSON.parse(rows[i+1]).forEach((activeCells, i) => {
+        let cells = activeCells.map(cell => {
+          return {
+            cell,
+            state: 'predicted-active'
+          };
+        });
+
+        modules.push(Object.assign({cells,
+                                    activeSynapsesByCell: {}},
+                                   configByModule[i]));
+      });
+
+      JSON.parse(rows[i+2]).forEach((activePoints, i) => {
+        modules[i].activePoints = activePoints;
+      });
+
+      let decodings = JSON.parse(rows[i+3]).map(
+        ([objectName, top, left, amountContained]) => {
+          return { objectName, top, left, amountContained };
+        });
+      currentTimestep.locationLayer = { modules, decodings };
+
+      i += 4;
+      break;
+    }
+    case 'locationLayer': {
+      let modules = [];
+
+      JSON.parse(rows[i+1]).forEach((module, i) => {
+        let [activeCells, segmentsForActiveCells] = module;
+
+        let prevActiveCells = (currentTimestep.reset || timesteps.length == 0)
+            ? []
+            : timesteps[timesteps.length-1].locationLayer.modules[i].cells.map(
+              d => d.cell);
+
+        let cells = activeCells.map(cell => {
+          return {
+            cell,
+            state: prevActiveCells.indexOf(cell) != -1
+              ? 'predicted-active'
+              : 'active'
+          };
+        });
+
+        let activeSynapsesByCell = {};
+
+        if (segmentsForActiveCells) {
+
+          activeCells.forEach(cell => {
+            activeSynapsesByCell[cell] = {};
+          });
+
+          for (let presynapticLayer in segmentsForActiveCells) {
+            segmentsForActiveCells[presynapticLayer].forEach((segments, ci) => {
+              let synapses = [];
+              segments.forEach(presynapticCells => {
+                synapses = synapses.concat(presynapticCells);
+              });
+
+              activeSynapsesByCell[activeCells[ci]][presynapticLayer] = synapses;
+            });
+          }
+        }
+
+        modules.push(Object.assign({cells, activeSynapsesByCell},
+                                   configByModule[i]));
+      });
+
+      JSON.parse(rows[i+2]).forEach((activePoints, i) => {
+        modules[i].activePoints = activePoints;
+      });
+
+      let decodings = JSON.parse(rows[i+3]).map(
+        ([objectName, top, left, amountContained]) => {
+          return { objectName, top, left, amountContained };
+        });
+      currentTimestep.locationLayer = { modules, decodings };
+
+      i += 4;
+      break;
+    }
+    case 'inputLayer': {
+      let activeSynapsesByCell = {};
+
+      let [activeCells, predictedCells, segmentsForActiveCells,
+           segmentsForPredictedCells] = JSON.parse(rows[i+1]);
+
+      let cells = activeCells.map(cell => {
+        return {
+          cell,
+          state: predictedCells.indexOf(cell) != -1
+            ? 'predicted-active'
+            : 'active'
+        };
+      });
+
+      if (segmentsForActiveCells) {
+        activeCells.forEach(cell => {
+          activeSynapsesByCell[cell] = {};
+        });
+
+        for (let presynapticLayer in segmentsForActiveCells) {
+          segmentsForActiveCells[presynapticLayer].forEach((segments, ci) => {
+            let synapses = [];
+            segments.forEach(presynapticCells => {
+              synapses = synapses.concat(presynapticCells);
+            });
+
+            activeSynapsesByCell[activeCells[ci]][presynapticLayer] = synapses;
+          });
+        }
+      }
+
+      let {activeCellDecodings, predictedCellDecodings} = JSON.parse(rows[i+2]);
+
+      let activeCellDecodings2 = activeCellDecodings.map(
+        ([objectName, top, left, amountContained]) => {
+          return { objectName, top, left, amountContained };
+        });
+      let predictedCellDecodings2 = predictedCellDecodings.map(
+        ([objectName, top, left, amountContained]) => {
+          return { objectName, top, left, amountContained };
+        });
+
+      currentTimestep.inputLayer = {
+        cells, activeSynapsesByCell,
+        decodings: activeCellDecodings2,
+        dimensions: {rows: 32, cols: 150},
+        predictedCells: []
+      };
+
+      if (timesteps.length > 0 &&
+          timesteps[timesteps.length - 1].type == 'move') {
+        let prevTimestep = timesteps[timesteps.length - 1];
+
+        let synapsesByPredictedCell = {};
+
+        let cells2 = predictedCells.map(cell => {
+          return {
+            cell,
+            state: 'predicted'
+          };
+        });
+
+        predictedCells.forEach(cell => {
+          synapsesByPredictedCell[cell] = {};
+        });
+
+        for (let presynapticLayer in segmentsForPredictedCells) {
+          segmentsForPredictedCells[presynapticLayer].forEach((segments, ci) => {
+            let synapses = [];
+            segments.forEach(presynapticCells => {
+              synapses = synapses.concat(presynapticCells);
+            });
+
+            synapsesByPredictedCell[predictedCells[ci]][presynapticLayer] = synapses;
+          });
+        }
+
+        prevTimestep.inputLayer = {
+          predictedCells,
+          activeSynapsesByCell: synapsesByPredictedCell,
+          decodings: predictedCellDecodings2,
+          cells: cells2,
+          dimensions: {rows: 32, cols: 150}
+        };
+      }
+
+      i += 3;
+      break;
+    }
+    case 'objectLayer': {
+      let [activeCells, segmentsForActiveCells] = JSON.parse(rows[i+1]);
+
+      let prevActiveCells = (currentTimestep.reset || timesteps.length == 0)
+          ? []
+          : timesteps[timesteps.length-1].objectLayer.cells.map(d => d.cell);
+
+      let cells = activeCells.map(cell => {
+        return {
+          cell,
+          state: prevActiveCells.indexOf(cell) != -1
+            ? 'predicted-active'
+            : 'active'
+        };
+      });
+
+      let activeSynapsesByCell = {};
+      if (segmentsForActiveCells) {
+
+        activeCells.forEach(cell => {
+          activeSynapsesByCell[cell] = {};
+        });
+
+        for (let presynapticLayer in segmentsForActiveCells) {
+          segmentsForActiveCells[presynapticLayer].forEach((segments, ci) => {
+            let synapses = [];
+            segments.forEach(presynapticCells => {
+              synapses = synapses.concat(presynapticCells);
+            });
+
+            activeSynapsesByCell[activeCells[ci]][presynapticLayer] = synapses;
+          });
+        }
+      }
+
+      let decodings = JSON.parse(rows[i+2]);
+      currentTimestep.objectLayer = Object.assign(
+        {cells, activeSynapsesByCell, decodings},
+        {dimensions: {rows: 16, cols: 256}});
+      i += 3;
+      break;
+    }
+    case 'objectPlacements': {
+      objectPlacements = JSON.parse(rows[i+1]);
+
+      worldFeatures = [];
+      for (let objectName in objects) {
+        let objectPlacement = objectPlacements[objectName];
+        objects[objectName].forEach(({name, top, left, width, height}) => {
+          worldFeatures.push({
+            name, width, height,
+            top: top + objectPlacement[0],
+            left: left + objectPlacement[1]
+          });
+        });
+      }
+
+      i += 2;
+      break;
+    }
+    default:
+      if (rows[i] == null || rows[i] == '') {
+        i++;
+      } else {
+        throw `Unrecognized: ${rows[i]}`;
+      }
+    }
+  }
+
+  endTimestep();
+
+  return {
+    timesteps, worldDims, configByModule, featureColor, objects
+  };
+}
+
+let secondColumnLeft = 180,
+    secondRowTop = 220,
+    thirdRowTop = 428,
+    columnWidth = 170;
+
+let boxes = {
+  location: {
+    left: 0, top: secondRowTop, width: columnWidth, height: 180, text: 'location layer',
+    bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
+    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+  },
+  input: {
+    left: secondColumnLeft, top: secondRowTop, width: columnWidth, height: 180, text: 'feature-location pair layer',
+    bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
+    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+  },
+  object: {
+    left: secondColumnLeft, top: 12, width: columnWidth, height: 180, text: 'object layer',
+    bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
+    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+  },
+  motion: {
+    left: 0, top: thirdRowTop, width: columnWidth, height: 81, text: 'motion input',
+    bitsLeft: 0, bitsTop: 0,
+    decodingsLeft: 85, decodingsTop: 36,
+    secondary: true
+  },
+  feature: {
+    left: secondColumnLeft, top: thirdRowTop, width: columnWidth, height: 81, text: 'feature input',
+    bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 5,
+    decodingsLeft: 65, decodingsTop: 30,
+    secondary: true
+  },
+  world: {
+    left: 370, top: 120, width: 230, height: 230, text: 'the world'
+  }
+};
+
+function printRecording(node, text) {
+  // Constants
+  let margin = {top: 5, right: 5, bottom: 15, left: 5},
+      width = 600,
+      height = 495,
+      parsed = parseData(text);
+
+  // Mutable state
+  let iTimestep = 0,
+      iLocationModule = null,
+      selectedLocationCell = null,
+      selectedInputCell = null,
+      selectedObjectCell = null,
+      highlightedCellsByLayer = {};
+
+  // Allow a mix of SVG and HTML
+  let html = d3.select(node)
+        .append('div')
+          .style('margin-left', 'auto')
+          .style('margin-right', 'auto')
+          .style('position', 'relative')
+          .style('width', `${width + margin.left + margin.right}px`),
+      svg = html.append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom);
+
+  // Add keyboard navigation
+  html
+    .attr('tabindex', 0)
+    .on('keydown', function() {
+      switch (d3.event.keyCode) {
+      case 37: // Left
+        iTimestep--;
+        if (iTimestep < 0) {iTimestep = parsed.timesteps.length - 1;}
+        onSelectedTimestepChanged();
+        d3.event.preventDefault();
+        break;
+      case 39: // Right
+        iTimestep = (iTimestep+1)%parsed.timesteps.length;
+        onSelectedTimestepChanged();
+        d3.event.preventDefault();
+        break;
+      }
+    });
+
+  // Make the SVG a clickable slideshow
+  let slideshow = svg.append('g')
+      .on('click', () => {
+        iTimestep = (iTimestep + 1) % parsed.timesteps.length;
+        onSelectedTimestepChanged();
+      });
+
+  slideshow.append('rect')
+      .attr('fill', 'transparent')
+      .attr('stroke', 'none')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.bottom + margin.top + 10);
+
+  let container = slideshow
+      .append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`);
+
+  // Arrange the boxes
+  let box = container.selectAll('.box')
+      .data([boxes.location,
+             boxes.input,
+             boxes.object,
+             boxes.feature,
+             boxes.motion]);
+
+  box = box.enter().append('g')
+    .attr('class', 'layerBox')
+    .call(g => {
+      g.append('rect')
+        .attr('class', 'border')
+        .attr('fill', 'none');
+
+      g.append('g')
+        .attr('class', 'bits');
+
+      g.append('g')
+        .attr('class', 'decodings');
+    })
+    .merge(box)
+    .attr('transform', d => `translate(${d.left}, ${d.top})`);
+
+  box.select('.border')
+    .attr('width', d => d.width)
+    .attr('height', d => d.height)
+    .attr('stroke', d => d.secondary ? 'gray' : 'lightgray')
+    .attr('stroke-width', d => d.secondary ? 1 : 3)
+    .attr('stroke-dasharray', d => d.secondary ? "5,5" : null);
+
+  let [locationNode,
+       inputNode,
+       objectNode,
+       featureNode,
+       _] = box.select('.bits')
+        .attr('transform', d => `translate(${d.bitsLeft},${d.bitsTop})`)
+        .nodes()
+        .map(d3.select);
+  let [decodedLocationNode,
+       decodedInputNode,
+       decodedObjectNode,
+       decodedFeatureNode,
+       motionNode] = box.select('.decodings')
+        .attr('transform', d => `translate(${d.decodingsLeft},${d.decodingsTop})`)
+        .nodes()
+        .map(d3.select);
+
+  let worldNode = container.append('g')
+      .attr('transform', `translate(${boxes.world.left}, ${boxes.world.top})`);
+  svg.append('line')
+    .attr('stroke', 'gray')
+    .attr('stroke-width', 1)
+    .attr('x1', boxes.world.left - 5)
+    .attr('y1', 10)
+    .attr('x2', boxes.world.left - 5)
+    .attr('y2', 522);
+
+  let timelineNode = html
+      .append('div')
+      .style('padding-top', '5px')
+      .style('padding-left', '17px') // Because it hangs some text off the side.
+      .style('padding-right', '17px')
+      .style('text-align', 'center');
+
+  // Label the boxes
+  let boxLabel = html.selectAll('.boxLabel')
+      .data([boxes.location, boxes.input, boxes.object, boxes.motion,
+             boxes.feature, boxes.world]);
+
+  boxLabel.enter()
+    .append('div')
+      .attr('class', 'boxLabel')
+      .style('position', 'absolute')
+      .style('text-align', 'left')
+      .style('font', '10px Verdana')
+      .style('pointer-events', 'none')
+    .merge(boxLabel)
+      .style('left', d => `${d.left + 7}px`)
+      .style('top', d => `${d.top - 9}px`)
+      .text(d => d.text);
+
+  // Configure the charts
+  let locationModules = locationModulesChart()
+        .width(boxes.location.bitsWidth)
+        .height(boxes.location.bitsHeight)
+        .onCellSelected((iModule, cell) => {
+          iLocationModule = iModule;
+          selectedLocationCell = cell;
+          onLocationCellSelected();
+        }),
+      decodedLocation = decodedLocationsChart()
+        .width(boxes.location.decodingsWidth)
+        .height(boxes.location.decodingsHeight)
+        .color(parsed.featureColor),
+      inputLayer = layerOfCellsChart()
+        .width(boxes.input.bitsWidth)
+        .height(boxes.input.bitsHeight)
+        .columnMajorIndexing(true)
+        .onCellSelected(cell => {
+          selectedInputCell = cell;
+          onInputCellSelected();
+        }),
+      decodedInput = decodedLocationsChart()
+        .width(boxes.input.decodingsWidth)
+        .height(boxes.input.decodingsHeight)
+        .color(parsed.featureColor),
+      objectLayer = layerOfCellsChart()
+        .width(boxes.object.bitsWidth)
+        .height(boxes.object.bitsHeight)
+        .onCellSelected(cell => {
+          selectedObjectCell = cell;
+          onObjectCellSelected();
+        }),
+      decodedObject = decodedObjectsChart()
+        .width(boxes.object.decodingsWidth)
+        .height(boxes.object.decodingsHeight)
+        .color(parsed.featureColor),
+      featureInput = arrayOfAxonsChart()
+        .width(boxes.feature.bitsWidth)
+        .height(boxes.feature.bitsHeight),
+      decodedFeature = featureChart()
+        .color(parsed.featureColor)
+        .width(40)
+        .height(40),
+      motionInput = motionChart(),
+      world = worldChart()
+        .width(boxes.world.width)
+        .height(boxes.world.height)
+        .color(parsed.featureColor),
+      timeline = timelineChart().onchange(iTimestepNew => {
+        iTimestep = iTimestepNew;
+        onSelectedTimestepChanged();
+      });
+
+  calculateHighlightedCells();
+  draw();
+
+  //
+  // Lifecycle functions
+  //
+  function draw(incremental) {
+    locationNode.datum({
+      modules: parsed.timesteps[iTimestep].locationLayer.modules,
+      highlightedCells: highlightedCellsByLayer['locationLayer'] || []
+    }).call(locationModules);
+    decodedLocationNode.datum({
+      decodings: parsed.timesteps[iTimestep].locationLayer.decodings,
+      objects: parsed.objects
+    }).call(decodedLocation);
+
+    inputNode.datum(
+      Object.assign(
+        {highlightedCells: highlightedCellsByLayer['inputLayer'] || []},
+        parsed.timesteps[iTimestep].inputLayer))
+      .call(inputLayer);
+    decodedInputNode.datum({
+      decodings: parsed.timesteps[iTimestep].inputLayer.decodings,
+      objects: parsed.objects
+    }).call(decodedInput);
+
+    objectNode.datum(
+      Object.assign(
+        {highlightedCells: highlightedCellsByLayer['objectLayer'] || []},
+        parsed.timesteps[iTimestep].objectLayer))
+      .call(objectLayer);
+    decodedObjectNode.datum({
+      decodings: parsed.timesteps[iTimestep].objectLayer.decodings,
+      objects: parsed.objects
+    }).call(decodedObject);
+
+    featureNode.datum(parsed.timesteps[iTimestep].featureInput)
+      .call(featureInput);
+    decodedFeatureNode.datum(
+      {name: parsed.timesteps[iTimestep].featureInput.decodings[0]})
+      .call(decodedFeature);
+
+    motionNode.datum(parsed.timesteps[iTimestep].deltaLocation)
+      .call(motionInput);
+
+    worldNode.datum({
+      dims: parsed.worldDims,
+      location: parsed.timesteps[iTimestep].worldLocation,
+      selectedLocationModule: iLocationModule !== null
+        ? parsed.timesteps[iTimestep].locationLayer.modules[iLocationModule]
+        : null,
+      features: parsed.timesteps[iTimestep].worldFeatures,
+      selectedLocationCell
+    }).call(world);
+
+    timelineNode.datum({
+      timesteps: parsed.timesteps,
+      selectedIndex: iTimestep
+    }).call(incremental ? timeline.drawSelectedStep : timeline);
+  }
+
+  function onSelectedTimestepChanged() {
+    calculateHighlightedCells();
+    drawHighlightedCells();
+    draw(true);
+  }
+
+  function onLocationCellSelected() {
+    if (iLocationModule != null) {
+      let config = parsed.configByModule[iLocationModule],
+          module = parsed.timesteps[iTimestep].locationLayer.modules[iLocationModule];
+
+      worldNode.datum(d => {
+        d.selectedLocationModule = Object.assign({}, config, module);
+        d.selectedLocationCell = selectedLocationCell;
+        return d;
+      });
+
+      let synapsesByPresynapticLayer =
+          module.activeSynapsesByCell[selectedLocationCell];
+      if (synapsesByPresynapticLayer) {
+        highlightedCellsByLayer = synapsesByPresynapticLayer;
+      }
+    } else {
+      worldNode.datum(d => {
+        d.selectedLocationModule = null;
+        d.selectedLocationCell = null;
+        return d;
+      });
+    }
+
+    worldNode.call(world.drawFiringFields);
+
+    calculateHighlightedCells();
+    drawHighlightedCells();
+  }
+
+  function onInputCellSelected() {
+    calculateHighlightedCells();
+    drawHighlightedCells();
+  }
+
+  function onObjectCellSelected() {
+    calculateHighlightedCells();
+    drawHighlightedCells();
+  }
+
+  function calculateHighlightedCells() {
+    highlightedCellsByLayer = {};
+
+    // Selected location cell
+    if (iLocationModule != null) {
+      let module = parsed.timesteps[iTimestep].locationLayer.modules[iLocationModule];
+
+      let synapsesByPresynapticLayer =
+          module.activeSynapsesByCell[selectedLocationCell];
+      if (synapsesByPresynapticLayer) {
+        highlightedCellsByLayer = synapsesByPresynapticLayer;
+      }
+    }
+
+    // Selected input cell
+    if (selectedInputCell != null) {
+      let layer = parsed.timesteps[iTimestep].inputLayer,
+          synapsesByPresynapticLayer =
+            layer.activeSynapsesByCell[selectedInputCell];
+
+      if (synapsesByPresynapticLayer) {
+        highlightedCellsByLayer = synapsesByPresynapticLayer;
+      }
+    }
+
+    // Selected object cell
+    if (selectedObjectCell != null) {
+      let layer = parsed.timesteps[iTimestep].objectLayer,
+          synapsesByPresynapticLayer =
+            layer.activeSynapsesByCell[selectedObjectCell];
+
+      if (synapsesByPresynapticLayer) {
+        highlightedCellsByLayer = synapsesByPresynapticLayer;
+      }
+    }
+  }
+
+  function drawHighlightedCells() {
+    locationNode.datum(d => {
+      d.highlightedCells = highlightedCellsByLayer['locationLayer'] || [];
+      return d;
+    }).call(locationModules.drawHighlightedCells);
+
+    inputNode.datum(d => {
+      d.highlightedCells = highlightedCellsByLayer['inputLayer'] || [];
+      return d;
+    }).call(inputLayer.drawHighlightedCells);
+
+    objectNode.datum(d => {
+      d.highlightedCells = highlightedCellsByLayer['objectLayer'] || [];
+      return d;
+    }).call(objectLayer.drawHighlightedCells);
+  }
+}
+
+function printRecordingFromUrl(node, logUrl) {
+  d3.text(logUrl,
+          (error, contents) =>
+          printRecording(node, contents));
+}
+
+export {
+  printRecording,
+  printRecordingFromUrl
+};

--- a/projects/location_layer/visualizations/js/src/locationModuleInference.js
+++ b/projects/location_layer/visualizations/js/src/locationModuleInference.js
@@ -442,17 +442,17 @@ let boxes = {
   location: {
     left: 0, top: secondRowTop, width: columnWidth, height: 180, text: 'location layer',
     bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
-    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+    decodingsLeft: 20, decodingsTop: 85, decodingsWidth: 148, decodingsHeight: 90
   },
   input: {
     left: secondColumnLeft, top: secondRowTop, width: columnWidth, height: 180, text: 'feature-location pair layer',
     bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
-    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+    decodingsLeft: 20, decodingsTop: 85, decodingsWidth: 148, decodingsHeight: 90
   },
   object: {
     left: secondColumnLeft, top: 12, width: columnWidth, height: 180, text: 'object layer',
     bitsLeft: 10, bitsTop: 10, bitsWidth: 150, bitsHeight: 60,
-    decodingsLeft: 20, decodingsTop: 90, decodingsWidth: 148, decodingsHeight: 90
+    decodingsLeft: 20, decodingsTop: 85, decodingsWidth: 148, decodingsHeight: 90
   },
   motion: {
     left: 0, top: thirdRowTop, width: columnWidth, height: 81, text: 'motion input',

--- a/projects/location_layer/visualizations/js/src/locationModules.js
+++ b/projects/location_layer/visualizations/js/src/locationModules.js
@@ -1,0 +1,325 @@
+import * as d3 from 'd3';
+import {locationModulesChart} from './charts/locationModulesChart.js';
+import {motionChart} from './charts/motionChart.js';
+import {worldChart} from './charts/worldChart.js';
+
+/**
+ *
+ * Example timestep:
+ * {
+ *   worldLocation: {left: 42.0, top: 12.0},
+ *   reset: null,
+ *   locationLayer: {
+ *     modules: [
+ *       {activeCells: [],
+ *        activePoints: [],
+ *        activeSynapsesByCell: {}},
+ *     ]
+ *   },
+ *   deltaLocationInput: {
+ *   },
+ * };
+ */
+function parseData(text) {
+  let timesteps = [],
+      rows = text.split('\n');
+
+  // Row: world dimensions
+  let worldDims = JSON.parse(rows[0]);
+
+  let currentTimestep = null,
+      didReset = false,
+      locationInWorld = null;
+
+  // [{cellDimensions: [5,5], moduleMapDimensions: [20.0, 20.0], orientation: 0.2},
+  //  ...]
+  let configByModule = JSON.parse(rows[1]).map(d => {
+    d.dimensions = {rows: d.cellDimensions[0], cols: d.cellDimensions[1]};
+    return d;
+  });
+
+  function endTimestep() {
+    if (currentTimestep !== null) {
+      currentTimestep.worldLocation = locationInWorld;
+      timesteps.push(currentTimestep);
+    }
+
+    currentTimestep = null;
+  }
+
+  function beginNewTimestep(type) {
+    endTimestep();
+
+    currentTimestep = {
+      worldLocation: locationInWorld,
+      type
+    };
+
+    if (didReset) {
+      currentTimestep.reset = true;
+      didReset = false;
+    }
+  }
+
+  let i = 2;
+  while (i < rows.length) {
+    switch (rows[i]) {
+    case 'reset':
+      didReset = true;
+      i++;
+      break;
+    case 'move': {
+      beginNewTimestep('move');
+      let deltaLocation = JSON.parse(rows[i+1]);
+
+      currentTimestep.deltaLocation = {
+        top: deltaLocation[0],
+        left: deltaLocation[1]
+      };
+
+      i += 2;
+      break;
+    }
+    case 'locationInWorld': {
+      let location = JSON.parse(rows[i+1]);
+
+      locationInWorld = {top: location[0], left: location[1]};
+
+      i += 2;
+      break;
+    }
+    case 'shift': {
+      let modules = [];
+      JSON.parse(rows[i+1]).forEach((activeCells, i) => {
+        let cells = activeCells.map(cell => {
+          return {
+            cell,
+            state: 'predicted-active'
+          };
+        });
+
+        modules.push(Object.assign({cells}, configByModule[i]));
+      });
+
+      JSON.parse(rows[i+2]).forEach((activePoints, i) => {
+        modules[i].activePoints = activePoints;
+      });
+
+      currentTimestep.locationLayer = { modules };
+
+      i += 3;
+      break;
+    }
+    default:
+      if (rows[i] == null || rows[i] == '') {
+        i++;
+      } else {
+        throw `Unrecognized: ${rows[i]}`;
+      }
+    }
+  }
+
+  endTimestep();
+
+  return {
+    timesteps, worldDims, configByModule
+  };
+}
+
+let boxes = {
+  location: {
+    left: 0, top: 20, width: 260, height: 140, text: 'location layer',
+    bitsLeft: 0, bitsTop: 0, bitsWidth: 260, bitsHeight: 140,
+    decodingsLeft: 0, decodingsTop: 0, decodingsWidth: 0, decodingsHeight: 0
+  },
+  motion: {
+    left: 0, top: 190, width: 260, height: 81, text: 'motion input',
+    bitsLeft: 0, bitsTop: 0,
+    decodingsLeft: 130, decodingsTop: 36,
+    secondary: true
+  },
+  world: {
+    left: 280, top: 34, width: 230, height: 230, text: 'the world'
+  }
+};
+
+function printRecording(node, text) {
+  // Constants
+  let margin = {top: 5, right: 15, bottom: 15, left: 15},
+      width = 510,
+      height = 270,
+      parsed = parseData(text);
+
+  // Mutable state
+  let iTimestep = 0,
+      iLocationModule = null,
+      selectedLocationCell = null;
+
+  // Allow a mix of SVG and HTML
+  let html = d3.select(node)
+        .append('div')
+          .style('margin-left', 'auto')
+          .style('margin-right', 'auto')
+          .style('position', 'relative')
+          .style('width', `${width + margin.left + margin.right}px`),
+      svg = html.append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom);
+
+  // Add keyboard navigation
+  html
+    .attr('tabindex', 0)
+    .on('keydown', function() {
+      switch (d3.event.keyCode) {
+      case 37: // Left
+        iTimestep--;
+          if (iTimestep < 0) {iTimestep = parsed.timesteps.length - 1;}
+        draw(true);
+        d3.event.preventDefault();
+        break;
+      case 39: // Right
+        iTimestep = (iTimestep+1)%parsed.timesteps.length;
+        draw(true);
+        d3.event.preventDefault();
+        break;
+      }
+    });
+
+  // Make the SVG a clickable slideshow
+  let slideshow = svg.append('g')
+      .on('click', () => {
+        iTimestep = (iTimestep + 1) % parsed.timesteps.length;
+        draw(true);
+      });
+
+  slideshow.append('rect')
+      .attr('fill', 'transparent')
+      .attr('stroke', 'none')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.bottom + margin.top + 10);
+
+  let container = slideshow
+      .append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`);
+
+  // Arrange the boxes
+  let box = container.selectAll('.box')
+      .data([boxes.location,
+             boxes.motion]);
+
+  box = box.enter().append('g')
+    .attr('class', 'layerBox')
+    .call(g => {
+      g.append('rect')
+        .attr('class', 'border')
+        .attr('fill', 'none');
+
+      g.append('g')
+        .attr('class', 'bits');
+
+      g.append('g')
+        .attr('class', 'decodings');
+    })
+    .merge(box)
+    .attr('transform', d => `translate(${d.left}, ${d.top})`);
+
+  box.select('.border')
+    .attr('width', d => d.width)
+    .attr('height', d => d.height)
+    .attr('stroke', d => d.secondary ? 'gray' : 'lightgray')
+    .attr('stroke-width', d => d.secondary ? 1 : 3)
+    .attr('stroke-dasharray', d => d.secondary ? "5,5" : null);
+
+  let [locationNode,
+       _] = box.select('.bits')
+        .attr('transform', d => `translate(${d.bitsLeft},${d.bitsTop})`)
+        .nodes()
+        .map(d3.select);
+  let [decodedLocationNode,
+       motionNode] = box.select('.decodings')
+        .attr('transform', d => `translate(${d.decodingsLeft},${d.decodingsTop})`)
+        .nodes()
+        .map(d3.select);
+
+  let worldNode = container.append('g')
+      .attr('transform', `translate(${boxes.world.left}, ${boxes.world.top})`);
+
+  // Label the boxes
+  let boxLabel = html.selectAll('.boxLabel')
+      .data([boxes.location, boxes.motion, boxes.world]);
+
+  boxLabel.enter()
+    .append('div')
+      .attr('class', 'boxLabel')
+      .style('position', 'absolute')
+      .style('text-align', 'left')
+      .style('font', '10px Verdana')
+      .style('pointer-events', 'none')
+    .merge(boxLabel)
+      .style('left', d => `${d.left + 17}px`)
+      .style('top', d => `${d.top - 9}px`)
+      .text(d => d.text);
+
+  // Configure the charts
+  let locationModules = locationModulesChart()
+        .width(boxes.location.bitsWidth)
+        .height(boxes.location.bitsHeight)
+        .onCellSelected((iModule, cell) => {
+          iLocationModule = iModule;
+          selectedLocationCell = cell;
+          onLocationCellSelected();
+        }),
+      motionInput = motionChart(),
+      world = worldChart()
+        .width(boxes.world.width)
+        .height(boxes.world.height)
+        .color(parsed.featureColor);
+
+  draw();
+
+  //
+  // Lifecycle functions
+  //
+  function draw(incremental) {
+    locationNode.datum({
+      modules: parsed.timesteps[iTimestep].locationLayer.modules
+    }).call(locationModules);
+
+    motionNode.datum(parsed.timesteps[iTimestep].deltaLocation)
+      .call(motionInput);
+
+    worldNode.datum({
+      dims: parsed.worldDims,
+      location: parsed.timesteps[iTimestep].worldLocation,
+      selectedLocationModule: iLocationModule !== null
+        ? parsed.timesteps[iTimestep].locationLayer.modules[iLocationModule]
+        : null,
+      features: [],
+      selectedLocationCell
+    }).call(world);
+  }
+
+  function onLocationCellSelected() {
+    worldNode.datum(d => {
+      d.selectedLocationModule = iLocationModule !== null
+        ? Object.assign(
+          {},
+          parsed.configByModule[iLocationModule],
+          parsed.timesteps[iTimestep].locationLayer.modules[iLocationModule])
+        : null;
+      d.selectedLocationCell = selectedLocationCell;
+      return d;
+    }).call(world.drawFiringFields);
+  }
+}
+
+function printRecordingFromUrl(node, csvUrl) {
+  d3.text(csvUrl,
+          (error, contents) =>
+          printRecording(node, contents));
+}
+
+export {
+  printRecording,
+  printRecordingFromUrl
+};

--- a/projects/location_layer/visualizations/js/src/shapes/arrowShape.js
+++ b/projects/location_layer/visualizations/js/src/shapes/arrowShape.js
@@ -1,0 +1,51 @@
+function arrowShape() {
+  var length,
+      width,
+      markerLength,
+      markerWidth;
+
+  let shape = function(_) {
+    let start = `M ${-length/2} ${-width/2}`;
+
+    let markerStart = length/2 - markerLength;
+
+    let n1 = `L ${markerStart} ${-width/2}`;
+    let n2 = `L ${markerStart} ${-markerWidth/2}`;
+    let n3 = `L ${length/2} 0`;
+    let n4 = `L ${markerStart} ${markerWidth/2}`;
+    let n5 = `L ${markerStart} ${width/2}`;
+    let n6 = `L ${-length/2} ${width/2}`;
+
+    let end = 'Z';
+
+    return [start, n1, n2, n3, n4, n5, n6, end].join(' ');
+  };
+
+  shape.arrowLength = function(_) {
+    if (!arguments.length) return length;
+    length = _;
+    return shape;
+  };
+
+  shape.arrowWidth = function(_) {
+    if (!arguments.length) return width;
+    width = _;
+    return shape;
+  };
+
+  shape.markerLength = function(_) {
+    if (!arguments.length) return markerLength;
+    markerLength = _;
+    return shape;
+  };
+
+  shape.markerWidth = function(_) {
+    if (!arguments.length) return markerWidth;
+    markerWidth = _;
+    return shape;
+  };
+
+  return shape;
+}
+
+export {arrowShape};

--- a/projects/location_layer/visualizations/location-module-inference.html
+++ b/projects/location_layer/visualizations/location-module-inference.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>2D space, 1-layer location</title>
+    <title>Location module inference</title>
     <script src="build/htmresearchviz0-bundle.js"></script>
     <style>
       body {
@@ -55,10 +55,10 @@
       }
 
       .singleVisualization {
-          width: 985px;
+          max-width: 830px;
           margin-left: auto;
           margin-right: auto;
-          margin-bottom: 100px;'
+          margin-bottom: 200px;
       }
     </style>
   </head>
@@ -72,7 +72,7 @@
         div.setAttribute('class', 'singleVisualization noselect');
 
         document.getElementById('graphics').appendChild(div);
-        htmresearchviz0.printRecording(div, text);
+        htmresearchviz0.locationModuleInference.printRecording(div, text);
       }
 
       function handleFile(file) {
@@ -82,7 +82,7 @@
           handleFileContents(fileReader.result);
         };
         fileReader.onerror = function (e) {
-          throw 'Error reading CSV file';
+          throw 'Error reading log file';
         };
 
         fileReader.readAsText(file);
@@ -107,14 +107,14 @@
     <input id="fileInput"
            type="file"
            onchange="handleFiles(this.files)"
-           accept="application/csv"
+           accept="application/log"
            style="display:none;"
            multiple="true"></input>
 
     <label for="fileInput">
       <div class="fileDrop clickable">
         <div class="fileDropText noselect">
-          <span>Drop a CSV file here</span>
+          <span>Drop a log file here</span>
           <br />
           <div class="bigPlus">+</div>
           <span>(or just click)</span>

--- a/projects/location_layer/visualizations/location-modules.html
+++ b/projects/location_layer/visualizations/location-modules.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>2D space, 1-layer location</title>
+    <title>Location modules</title>
     <script src="build/htmresearchviz0-bundle.js"></script>
     <style>
       body {
@@ -55,10 +55,10 @@
       }
 
       .singleVisualization {
-          width: 985px;
+          width: 830px;
           margin-left: auto;
           margin-right: auto;
-          margin-bottom: 100px;'
+          margin-bottom: 200px;
       }
     </style>
   </head>
@@ -72,7 +72,7 @@
         div.setAttribute('class', 'singleVisualization noselect');
 
         document.getElementById('graphics').appendChild(div);
-        htmresearchviz0.printRecording(div, text);
+        htmresearchviz0.locationModules.printRecording(div, text);
       }
 
       function handleFile(file) {
@@ -82,7 +82,7 @@
           handleFileContents(fileReader.result);
         };
         fileReader.onerror = function (e) {
-          throw 'Error reading CSV file';
+          throw 'Error reading log file';
         };
 
         fileReader.readAsText(file);
@@ -107,14 +107,14 @@
     <input id="fileInput"
            type="file"
            onchange="handleFiles(this.files)"
-           accept="application/csv"
+           accept="application/log"
            style="display:none;"
            multiple="true"></input>
 
     <label for="fileInput">
       <div class="fileDrop clickable">
         <div class="fileDropText noselect">
-          <span>Drop a CSV file here</span>
+          <span>Drop a log file here</span>
           <br />
           <div class="bigPlus">+</div>
           <span>(or just click)</span>

--- a/projects/location_layer/visualizations/package.json
+++ b/projects/location_layer/visualizations/package.json
@@ -8,16 +8,19 @@
   "repository": "https://github.com/numenta/nupic.research",
   "jsnext:main": "js/index",
   "scripts": {
-    "install": "rm -rf build && mkdir build && rollup -c -f umd -n htmresearchviz0 -o build/htmresearchviz0-bundle.js -- js/index.js && mkdir -p py/htmresearchviz0/package_data && cp build/htmresearchviz0-bundle.js py/htmresearchviz0/package_data/htmresearchviz0-bundle.js",
-    "postpublish": "zip -j build/htmresearchviz0.zip -- README.md build/htmresearchviz0-bundle.js && cp build/htmresearchviz0-bundle.js py/htmresearchviz0/package_data/htmresearchviz0-bundle.js"
+    "build": "rm -rf build && mkdir build && rollup -c -f umd -n htmresearchviz0 -o build/htmresearchviz0-bundle.js -- js/index.js && mkdir -p py/htmresearchviz0/package_data && cp build/htmresearchviz0-bundle.js py/htmresearchviz0/package_data/htmresearchviz0-bundle.js",
+    "postpublish": "zip -j build/htmresearchviz0.zip -- README.md build/htmresearchviz0-bundle.js && cp build/htmresearchviz0-bundle.js py/htmresearchviz0/package_data/htmresearchviz0-bundle.js",
+    "dev": "http-server && onchange 'js/**/*.js' -- npm run build"
   },
   "devDependencies": {
     "rollup": "0.41.6",
     "rollup-plugin-node-resolve": "^2.0.0",
     "tape": "4",
-    "uglify-js": "2"
+    "uglify-js": "2",
+    "onchange": "3.2.1",
+    "http-server": "0.10.0"
   },
   "dependencies": {
-    "d3": "^4.4.1"
+    "d3": "^4.9.1"
   }
 }

--- a/projects/location_layer/visualizations/py/htmresearchviz0/IPython_support.py
+++ b/projects/location_layer/visualizations/py/htmresearchviz0/IPython_support.py
@@ -64,3 +64,33 @@ def printSingleLayer2DExperiment(csvText):
            csvText.replace("\r", "\\r").replace("\n", "\\n"))
 
     display(HTML(addChart))
+
+
+def printLocationModuleInference(logText):
+    elementId = str(uuid.uuid1())
+    addChart = """
+    <div class="htmresearchviz-output" id="%s"></div>
+    <script>
+    require(['htmresearchviz0'], function(htmresearchviz0) {
+      htmresearchviz0.locationModuleInference.printRecording(document.getElementById('%s'), '%s');
+    });
+    </script>
+    """ % (elementId, elementId,
+           logText.replace("\r", "\\r").replace("\n", "\\n"))
+
+    display(HTML(addChart))
+
+
+def printLocationModulesRecording(logText):
+    elementId = str(uuid.uuid1())
+    addChart = """
+    <div class="htmresearchviz-output" id="%s"></div>
+    <script>
+    require(['htmresearchviz0'], function(htmresearchviz0) {
+      htmresearchviz0.locationModules.printRecording(document.getElementById('%s'), '%s');
+    });
+    </script>
+    """ % (elementId, elementId,
+           logText.replace("\r", "\\r").replace("\n", "\\n"))
+
+    display(HTML(addChart))


### PR DESCRIPTION
The main write-up: http://numenta.github.io/htmresearch/documents/location-layer/Early-findings-with-Location-Modules.html

This adds:

- `superficial_location_module.py` to the Algorithms folder.
- `location_module_experiment` in `projects/location_layer`
- Visualization: `locationModuleInference.js`. Also, a smaller `locationModules.js` which is a subset of the former. These central js files parse the data and lay out all of the pieces of the visualization. The pieces are a bunch of charts, which I put in a new "charts" folder.