### PR TITLE
RES-594: Move 'averageConvergencePoint' to 'L4L2Experiment' class

### DIFF
--- a/htmresearch/frameworks/layers/l2_l4_inference.py
+++ b/htmresearch/frameworks/layers/l2_l4_inference.py
@@ -86,6 +86,7 @@ import os
 import random
 import matplotlib.pyplot as plt
 import numpy as np
+from math import ceil
 from tabulate import tabulate
 
 from nupic.bindings.math import SparseMatrix
@@ -585,6 +586,59 @@ class L4L2Experiment(object):
       return self.statistics[experimentID]
 
 
+  def averageConvergencePoint(self, prefix, minOverlap, maxOverlap,
+                              settlingTime=1):
+
+    """
+    inferenceStats contains activity traces while the system visits each object.
+
+    Given the i'th object, inferenceStats[i] contains activity statistics for
+    each column for each region for the entire sequence of sensations.
+
+    For each object, compute the convergence time - the first point when all
+    L2 columns have converged.
+
+    Return the average convergence time and accuracy across all objects.
+
+    Given inference statistics for a bunch of runs, locate all traces with the
+    given prefix. For each trace locate the iteration where it finally settles
+    on targetValue. Return the average settling iteration and accuracy across
+    all runs.
+
+    :param prefix: Use this prefix to filter relevant stats.
+    :param minOverlap: Min target overlap
+    :param maxOverlap: Max target overlap
+    :param settlingTime: Setting time between iteration. Default 1
+    :return: Average settling iteration and accuracy across all runs
+    """
+    convergenceSum = 0.0
+    numCorrect = 0.0
+    inferenceLength = 1000000
+
+    # For each object
+    for stats in self.statistics:
+
+      # For each L2 column locate convergence time
+      convergencePoint = 0.0
+      for key in stats.iterkeys():
+        if prefix in key:
+          inferenceLength = len(stats[key])
+          columnConvergence = self._locateConvergencePoint(
+            stats[key], minOverlap, maxOverlap)
+
+          # Ensure this column has converged by the last iteration
+          # assert(columnConvergence <= len(stats[key]))
+
+          convergencePoint = max(convergencePoint, columnConvergence)
+
+      convergenceSum += ceil(float(convergencePoint) / settlingTime)
+
+      if ceil(float(convergencePoint) / settlingTime) <= inferenceLength:
+        numCorrect += 1
+
+    return convergenceSum / len(self.statistics), numCorrect / len(self.statistics)
+
+
   def printProfile(self, reset=False):
     """
     Prints profiling information.
@@ -695,7 +749,6 @@ class L4L2Experiment(object):
       overlaps[i, :] = representations.rightVecSumAtNZSparse(activeCells)
 
     return overlaps
-
 
 
   def getCurrentClassification(self, minOverlap=None, includeZeros=True):
@@ -839,6 +892,21 @@ class L4L2Experiment(object):
       "synPermInactiveDec": 0.0005,
       "boostStrength": 0.0,
     }
+
+
+  def _locateConvergencePoint(self, stats, minOverlap, maxOverlap):
+    """
+    Walk backwards through stats until you locate the first point that diverges
+    from target overlap values.  We need this to handle cases where it might get
+    to target values, diverge, and then get back again.  We want the last
+    convergence point.
+    """
+    for i, v in enumerate(stats[::-1]):
+      if not (v >= minOverlap and v <= maxOverlap):
+        return len(stats) - i + 1
+
+    # Never differs - converged in one iteration
+    return 1
 
 
   def _unsetLearningMode(self):

--- a/projects/combined_sequences/combined_sequences.py
+++ b/projects/combined_sequences/combined_sequences.py
@@ -23,7 +23,6 @@ This file plots the behavior of L4-L2-TM network as you train it on sequences.
 """
 
 import os
-from math import ceil
 import numpy
 import time
 import cPickle
@@ -42,66 +41,6 @@ from htmresearch.frameworks.layers.combined_sequence_experiment import (
 from htmresearch.frameworks.layers.object_machine_factory import (
   createObjectMachine
 )
-
-
-def locateConvergencePoint(stats, minOverlap, maxOverlap):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from target overlap values.  We need this to handle cases where it might get
-  to target values, diverge, and then get back again.  We want the last
-  convergence point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if not (v >= minOverlap and v <= maxOverlap):
-      return len(stats)-i + 1
-
-  # Never differs - converged in one iteration
-  return 1
-
-
-def averageConvergencePoint(inferenceStats, prefix, minOverlap, maxOverlap,
-                            settlingTime):
-  """
-  inferenceStats contains activity traces while the system visits each object.
-
-  Given the i'th object, inferenceStats[i] contains activity statistics for
-  each column for each region for the entire sequence of sensations.
-
-  For each object, compute the convergence time - the first point when all
-  L2 columns have converged.
-
-  Return the average convergence time across all objects.
-
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  convergenceSum = 0.0
-  numCorrect = 0.0
-  inferenceLength = 1000000
-
-  # For each object
-  for stats in inferenceStats:
-
-    # For each L2 column locate convergence time
-    convergencePoint = 0.0
-    for key in stats.iterkeys():
-      if prefix in key:
-        inferenceLength = len(stats[key])
-        columnConvergence = locateConvergencePoint(
-          stats[key], minOverlap, maxOverlap)
-
-        # Ensure this column has converged by the last iteration
-        # assert(columnConvergence <= len(stats[key]))
-
-        convergencePoint = max(convergencePoint, columnConvergence)
-
-    convergenceSum += ceil(float(convergencePoint)/settlingTime)
-
-    if ceil(float(convergencePoint)/settlingTime) <= inferenceLength:
-      numCorrect += 1
-
-  return convergenceSum/len(inferenceStats), numCorrect/len(inferenceStats)
 
 
 def runExperiment(args):
@@ -360,8 +299,8 @@ def runExperiment(args):
 
   # Compute overall inference statistics
   infStats = exp.getInferenceStats()
-  convergencePoint, accuracy = averageConvergencePoint(
-    infStats,"L2 Representation", 30, 40, 1)
+  convergencePoint, accuracy = exp.averageConvergencePoint(
+    "L2 Representation", 30, 40, 1)
 
   predictedActive = numpy.zeros(len(infStats))
   predicted = numpy.zeros(len(infStats))

--- a/projects/combined_sequences/sequence_convergence.py
+++ b/projects/combined_sequences/sequence_convergence.py
@@ -43,66 +43,6 @@ from htmresearch.frameworks.layers.object_machine_factory import (
 )
 
 
-def locateConvergencePoint(stats, minOverlap, maxOverlap):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from target overlap values.  We need this to handle cases where it might get
-  to target values, diverge, and then get back again.  We want the last
-  convergence point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if not (v >= minOverlap and v <= maxOverlap):
-      return len(stats)-i + 1
-
-  # Never differs - converged in one iteration
-  return 1
-
-
-def averageConvergencePoint(inferenceStats, prefix, minOverlap, maxOverlap,
-                            settlingTime):
-  """
-  inferenceStats contains activity traces while the system visits each object.
-
-  Given the i'th object, inferenceStats[i] contains activity statistics for
-  each column for each region for the entire sequence of sensations.
-
-  For each object, compute the convergence time - the first point when all
-  L2 columns have converged.
-
-  Return the average convergence time across all objects.
-
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  convergenceSum = 0.0
-  numCorrect = 0.0
-  inferenceLength = 1000000
-
-  # For each object
-  for stats in inferenceStats:
-
-    # For each L2 column locate convergence time
-    convergencePoint = 0.0
-    for key in stats.iterkeys():
-      if prefix in key:
-        inferenceLength = len(stats[key])
-        columnConvergence = locateConvergencePoint(
-          stats[key], minOverlap, maxOverlap)
-
-        # Ensure this column has converged by the last iteration
-        # assert(columnConvergence <= len(stats[key]))
-
-        convergencePoint = max(convergencePoint, columnConvergence)
-
-    convergenceSum += ceil(float(convergencePoint)/settlingTime)
-
-    if ceil(float(convergencePoint)/settlingTime) <= inferenceLength:
-      numCorrect += 1
-
-  return convergenceSum/len(inferenceStats), numCorrect/len(inferenceStats)
-
-
 def runExperiment(args):
   """
   Runs the experiment.  What did you think this does?
@@ -241,8 +181,8 @@ def runExperiment(args):
 
   # Compute overall inference statistics
   infStats = exp.getInferenceStats()
-  convergencePoint, accuracy = averageConvergencePoint(
-    infStats,"L2 Representation", 30, 40, 1)
+  convergencePoint, accuracy = exp.averageConvergencePoint(
+    "L2 Representation", 30, 40, 1)
 
   predictedActive = numpy.zeros(len(infStats))
   predicted = numpy.zeros(len(infStats))

--- a/projects/l2_pooling/multi_column_convergence.py
+++ b/projects/l2_pooling/multi_column_convergence.py
@@ -26,7 +26,6 @@ or adjust the confusion between objects.
 
 import random
 import os
-from math import ceil
 import pprint
 import numpy
 import cPickle
@@ -39,59 +38,6 @@ from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
 from htmresearch.frameworks.layers.object_machine_factory import (
   createObjectMachine
 )
-
-def locateConvergencePoint(stats, minOverlap, maxOverlap):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from target overlap values.  We need this to handle cases where it might get
-  to target values, diverge, and then get back again.  We want the last
-  convergence point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if not (v >= minOverlap and v <= maxOverlap):
-      return len(stats)-i + 1
-
-  # Never differs - converged in one iteration
-  return 1
-
-
-def averageConvergencePoint(inferenceStats, prefix, minOverlap, maxOverlap,
-                            settlingTime):
-  """
-  inferenceStats contains activity traces while the system visits each object.
-
-  Given the i'th object, inferenceStats[i] contains activity statistics for
-  each column for each region for the entire sequence of sensations.
-
-  For each object, compute the convergence time - the first point when all
-  L2 columns have converged.
-
-  Return the average convergence time across all objects.
-
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  convergenceSum = 0.0
-
-  # For each object
-  for stats in inferenceStats:
-
-    # For each L2 column locate convergence time
-    convergencePoint = 0.0
-    for key in stats.iterkeys():
-      if prefix in key:
-        columnConvergence = locateConvergencePoint(
-          stats[key], minOverlap, maxOverlap)
-
-        # Ensure this column has converged by the last iteration
-        # assert(columnConvergence <= len(stats[key]))
-
-        convergencePoint = max(convergencePoint, columnConvergence)
-
-    convergenceSum += ceil(float(convergencePoint)/settlingTime)
-
-  return convergenceSum/len(inferenceStats)
 
 
 def objectConfusion(objects):
@@ -297,8 +243,8 @@ def runExperiment(args):
         onePlot=False,
       )
 
-  convergencePoint = averageConvergencePoint(
-    exp.getInferenceStats(),"L2 Representation", 30, 40, settlingTime)
+  convergencePoint, _ = exp.averageConvergencePoint("L2 Representation", 30, 40,
+                                                 settlingTime)
 
 
   print "# objects {} # features {} # locations {} # columns {} trial # {} network type {}".format(

--- a/projects/l2_pooling/multi_column_convergence.py
+++ b/projects/l2_pooling/multi_column_convergence.py
@@ -23,10 +23,10 @@ This file plots the convergence of L4-L2 as you increase the number of columns,
 or adjust the confusion between objects.
 
 """
+import argparse
 
 import random
 import os
-import pprint
 import numpy
 import cPickle
 from multiprocessing import Pool, cpu_count
@@ -38,43 +38,6 @@ from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
 from htmresearch.frameworks.layers.object_machine_factory import (
   createObjectMachine
 )
-
-
-def objectConfusion(objects):
-  """
-  For debugging, print overlap between each pair of objects.
-  """
-  sumCommonLocations = 0
-  sumCommonFeatures = 0
-  sumCommonPairs = 0
-  numObjects = 0
-  commonPairHistogram = numpy.zeros(len(objects[0]), dtype=numpy.int32)
-  for o1,s1 in objects.iteritems():
-    for o2,s2 in objects.iteritems():
-      if o1 != o2:
-        # Count number of common locations id's and common feature id's
-        commonLocations = 0
-        commonFeatures = 0
-        for pair1 in s1:
-          for pair2 in s2:
-            if pair1[0] == pair2[0]: commonLocations += 1
-            if pair1[1] == pair2[1]: commonFeatures += 1
-
-        # print "Confusion",o1,o2,", common pairs=",len(set(s1)&set(s2)),
-        # print ", common locations=",commonLocations,"common features=",commonFeatures
-
-        assert(len(set(s1)&set(s2)) != len(s1) ), "Two objects are identical!"
-
-        sumCommonPairs += len(set(s1)&set(s2))
-        sumCommonLocations += commonLocations
-        sumCommonFeatures += commonFeatures
-        commonPairHistogram[len(set(s1)&set(s2))] += 1
-        numObjects += 1
-
-  print "Average common pairs=", sumCommonPairs / float(numObjects),
-  print ", locations=",sumCommonLocations / float(numObjects),
-  print ", features=",sumCommonFeatures / float(numObjects)
-  print "Common pair histogram=",commonPairHistogram
 
 
 def runExperiment(args):
@@ -156,7 +119,12 @@ def runExperiment(args):
                                       numLocations=numLocations,
                                       numFeatures=numFeatures)
 
-  objectConfusion(objects.getObjects())
+  average, locations, features, histogram = objects.objectConfusion()
+
+  print "Average common pairs=", average,
+  print ", locations=", locations,
+  print ", features=", features
+  print "Common pair histogram=", histogram
 
   # print "Total number of objects created:",len(objects.getObjects())
   # print "Objects are:"

--- a/projects/l2_pooling/multi_column_synapse_sampling.py
+++ b/projects/l2_pooling/multi_column_synapse_sampling.py
@@ -91,38 +91,6 @@ def getL2Params():
   }
 
 
-def locateConvergencePoint(stats, targetValue):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from targetValue.  We need this to handle cases where it might get to
-  targetValue, diverge, and then get back again.  We want the last convergence
-  point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if v != targetValue:
-      return len(stats)-i
-
-  # Never differs - converged right away
-  return 0
-
-
-def averageConvergencePoint(inferenceStats, prefix, targetValue):
-  """
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  itSum = 0
-  itNum = 0
-  for stats in inferenceStats:
-    for key in stats.iterkeys():
-      if prefix in key:
-        itSum += locateConvergencePoint(stats[key], targetValue)
-        itNum += 1
-
-  return float(itSum)/itNum
-
-
 def runExperiment(args):
   """
   Run experiment.  What did you think this does?
@@ -239,8 +207,7 @@ def runExperiment(args):
     L2TimeInfer /= len(objects)
     args.update({"L2TimeInfer": L2TimeInfer})
 
-  convergencePoint = averageConvergencePoint(
-    exp.getInferenceStats(),"L2 Representation", 40)
+  convergencePoint, _ = exp.averageConvergencePoint("L2 Representation", 40, 40)
   print "objectSeed {} # distal syn {} # proximal syn {}, " \
         "# convergence point={:4.2f} train time {:4.3f} infer time {:4.3f}".format(
     objectSeed,

--- a/projects/thing_classification/thing_convergence.py
+++ b/projects/thing_classification/thing_convergence.py
@@ -84,60 +84,6 @@ def getL2Params():
   }
 
 
-def locateConvergencePoint(stats, minOverlap, maxOverlap):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from target overlap values.  We need this to handle cases where it might get
-  to target values, diverge, and then get back again.  We want the last
-  convergence point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if not (v >= minOverlap and v <= maxOverlap):
-      return len(stats)-i + 1
-
-  # Never differs - converged in one iteration
-  return 1
-
-
-def averageConvergencePoint(inferenceStats, prefix, minOverlap, maxOverlap,
-                            settlingTime):
-  """
-  inferenceStats contains activity traces while the system visits each object.
-
-  Given the i'th object, inferenceStats[i] contains activity statistics for
-  each column for each region for the entire sequence of sensations.
-
-  For each object, compute the convergence time - the first point when all
-  L2 columns have converged.
-
-  Return the average convergence time across all objects.
-
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  convergenceSum = 0.0
-
-  # For each object
-  for stats in inferenceStats:
-
-    # For each L2 column locate convergence time
-    convergencePoint = 0.0
-    for key in stats.iterkeys():
-      if prefix in key:
-        columnConvergence = locateConvergencePoint(
-          stats[key], minOverlap, maxOverlap)
-
-        # Ensure this column has converged by the last iteration
-        # assert(columnConvergence <= len(stats[key]))
-
-        convergencePoint = max(convergencePoint, columnConvergence)
-
-    convergenceSum += ceil(float(convergencePoint)/settlingTime)
-
-  return convergenceSum/len(inferenceStats)
-
-
 def loadThingObjects(numCorticalColumns=1, objDataPath='./data/'):
   """
   Load simulated sensation data on a number of different objects


### PR DESCRIPTION
Moved `averageConvergencePoint` function to `L4L2Experiment` and changed the experiments to use the new method.

@subutai @ywcui1990 Please review