### PR TITLE
RES-594: Refactor experiments to use 'averageConvergencePoint' from 'L4L2Experiment' class

### DIFF
--- a/projects/l2_pooling/multi_column_synapse_sampling.py
+++ b/projects/l2_pooling/multi_column_synapse_sampling.py
@@ -91,38 +91,6 @@ def getL2Params():
   }
 
 
-def locateConvergencePoint(stats, targetValue):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from targetValue.  We need this to handle cases where it might get to
-  targetValue, diverge, and then get back again.  We want the last convergence
-  point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if v != targetValue:
-      return len(stats)-i
-
-  # Never differs - converged right away
-  return 0
-
-
-def averageConvergencePoint(inferenceStats, prefix, targetValue):
-  """
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  itSum = 0
-  itNum = 0
-  for stats in inferenceStats:
-    for key in stats.iterkeys():
-      if prefix in key:
-        itSum += locateConvergencePoint(stats[key], targetValue)
-        itNum += 1
-
-  return float(itSum)/itNum
-
-
 def runExperiment(args):
   """
   Run experiment.  What did you think this does?
@@ -239,8 +207,7 @@ def runExperiment(args):
     L2TimeInfer /= len(objects)
     args.update({"L2TimeInfer": L2TimeInfer})
 
-  convergencePoint = averageConvergencePoint(
-    exp.getInferenceStats(),"L2 Representation", 40)
+  convergencePoint, _ = exp.averageConvergencePoint("L2 Representation", 40, 40)
   print "objectSeed {} # distal syn {} # proximal syn {}, " \
         "# convergence point={:4.2f} train time {:4.3f} infer time {:4.3f}".format(
     objectSeed,

--- a/projects/thing_classification/thing_convergence.py
+++ b/projects/thing_classification/thing_convergence.py
@@ -83,60 +83,6 @@ def getL2Params():
   }
 
 
-def locateConvergencePoint(stats, minOverlap, maxOverlap):
-  """
-  Walk backwards through stats until you locate the first point that diverges
-  from target overlap values.  We need this to handle cases where it might get
-  to target values, diverge, and then get back again.  We want the last
-  convergence point.
-  """
-  for i,v in enumerate(stats[::-1]):
-    if not (v >= minOverlap and v <= maxOverlap):
-      return len(stats)-i + 1
-
-  # Never differs - converged in one iteration
-  return 1
-
-
-def averageConvergencePoint(inferenceStats, prefix, minOverlap, maxOverlap,
-                            settlingTime):
-  """
-  inferenceStats contains activity traces while the system visits each object.
-
-  Given the i'th object, inferenceStats[i] contains activity statistics for
-  each column for each region for the entire sequence of sensations.
-
-  For each object, compute the convergence time - the first point when all
-  L2 columns have converged.
-
-  Return the average convergence time across all objects.
-
-  Given inference statistics for a bunch of runs, locate all traces with the
-  given prefix. For each trace locate the iteration where it finally settles
-  on targetValue. Return the average settling iteration across all runs.
-  """
-  convergenceSum = 0.0
-
-  # For each object
-  for stats in inferenceStats:
-
-    # For each L2 column locate convergence time
-    convergencePoint = 0.0
-    for key in stats.iterkeys():
-      if prefix in key:
-        columnConvergence = locateConvergencePoint(
-          stats[key], minOverlap, maxOverlap)
-
-        # Ensure this column has converged by the last iteration
-        # assert(columnConvergence <= len(stats[key]))
-
-        convergencePoint = max(convergencePoint, columnConvergence)
-
-    convergenceSum += ceil(float(convergencePoint)/settlingTime)
-
-  return convergenceSum/len(inferenceStats)
-
-
 def loadThingObjects(numCorticalColumns=1, objDataPath='./data/'):
   """
   Load simulated sensation data on a number of different objects


### PR DESCRIPTION
@subutai  Please review
Replaces conflicting PR #793 

This PR refactors most experiments using `averageConvergencePoint` from `L4L2Experiment` class.

The `multi_column_convergence` experiment is not part of this refactor because it is using a new version of this function called [averageConvergencePointNew](https://github.com/numenta/htmresearch/blob/master/projects/l2_pooling/multi_column_convergence.py#L98-L130) which was introduce with  PR #788 

Refactoring `averageConvergencePointNew` will be addressed in a separate PR.

