### PR TITLE
RES:684: Make CoordinateSensorRegion output compatible with ApicalTMPairRegion input

### DIFF
--- a/htmresearch/regions/CoordinateSensorRegion.py
+++ b/htmresearch/regions/CoordinateSensorRegion.py
@@ -62,21 +62,21 @@ class CoordinateSensorRegion(PyRegion):
       "outputs": {
         "dataOut": {
           "description": "Encoded coordinate SDR.",
-          "dataType": "uint",
+          "dataType": "Real32",
           "count": 0,
           "regionLevel": True,
           "isDefaultOutput": True,
         },
         "resetOut": {
           "description": "0/1 reset flag output.",
-          "dataType": "uint",
+          "dataType": "UInt32",
           "count": 1,
           "regionLevel": True,
           "isDefaultOutput": False,
         },
         "sequenceIdOut": {
           "description": "Sequence ID",
-          "dataType": "uint",
+          "dataType": "UInt32",
           "count": 1,
           "regionLevel": True,
           "isDefaultOutput": False,
@@ -93,21 +93,21 @@ class CoordinateSensorRegion(PyRegion):
         },
         "outputWidth": {
           "description": "Size of output vector",
-          "dataType": "uint",
+          "dataType": "UInt32",
           "accessMode": "ReadWrite",
           "count": 1,
           "defaultValue": 1000
         },
         "radius": {
           "description": "Radius around 'coordinate'",
-          "dataType": "uint",
+          "dataType": "UInt32",
           "accessMode": "ReadWrite",
           "count": 1,
           "defaultValue": 2
         },
         "verbosity": {
           "description": "Verbosity level",
-          "dataType": "uint",
+          "dataType": "UInt32",
           "accessMode": "ReadWrite",
           "count": 1
         },


### PR DESCRIPTION
The new link validation introduced to nupic.core (https://github.com/numenta/nupic.core/pull/1400) was causing a few tests and experiments to fail.
This PR will fix invalid link types between `CoordinateSensorRegion` and `ApicalTMPairRegion` regions and the related tests and experiments.
