### PR TITLE
Add model that more closely mimics rat entorhinal modules

### DIFF
--- a/htmresearch/frameworks/location/path_integration_union_narrowing.py
+++ b/htmresearch/frameworks/location/path_integration_union_narrowing.py
@@ -25,14 +25,56 @@ of unions of locations that are specific to objects.
 """
 
 import abc
+import math
 import random
+from collections import defaultdict
 
 import numpy as np
 
 from htmresearch.algorithms.apical_tiebreak_temporal_memory import (
   ApicalTiebreakPairMemory)
 from htmresearch.algorithms.column_pooler import ColumnPooler
-from htmresearch.algorithms.location_modules import Superficial2DLocationModule
+from htmresearch.algorithms.location_modules import (
+  Superficial2DLocationModule, ThresholdedGaussian2DLocationModule)
+
+
+RAT_BUMP_SIGMA = 0.18172
+
+
+def createRatModule(inverseReadoutResolution, scale, enlargeModuleFactor=1.,
+                    **kwargs):
+  """
+  @param inverseReadoutResolution (int or float)
+  Equivalent to 1/readoutResolution, but specified this way as a convenience
+  (because it's easier and less ambiguous to type 3 than to type 0.3333333). The
+  readout resolution specifies the diameter of the circle of phases in the
+  rhombus encoded by a bump. So when a bump of activity is converted into a set
+  of active cells, this circle of active cells will have a diameter of at least
+  this amount.
+
+  @param enlargeModuleFactor (float)
+  A multiplicative factor that's used to simulate the effect of having a larger
+  module, keeping the bump size fixed but making the module larger, so that the
+  bump is smaller relative to the size of the module. Equivalently, this shrinks
+  the bump, increases the precision of the readout, adds more cells, and
+  increases the scale so that the bump is the same size when overlayed on the
+  real world.
+  """
+
+  # Give the module enough precision in its learning so that the bump is the
+  # specified diameter when properly accounting for uncertainty.
+  learningCellsPerAxis = int(math.ceil(2*inverseReadoutResolution*enlargeModuleFactor))
+
+  readoutResolution = 1. / (enlargeModuleFactor*inverseReadoutResolution)
+  activeFiringRate = ThresholdedGaussian2DLocationModule.chooseReliableActiveFiringRate(
+    learningCellsPerAxis, RAT_BUMP_SIGMA, readoutResolution)
+
+  return ThresholdedGaussian2DLocationModule(
+    cellsPerAxis=learningCellsPerAxis,
+    activeFiringRate=activeFiringRate,
+    bumpSigma=RAT_BUMP_SIGMA,
+    scale=scale*enlargeModuleFactor,
+    **kwargs)
 
 
 class PIUNCorticalColumn(object):
@@ -45,7 +87,7 @@ class PIUNCorticalColumn(object):
   arrives, call sensoryCompute.
   """
 
-  def __init__(self, locationConfigs, L4Overrides=None):
+  def __init__(self, locationConfigs, L4Overrides=None, useGaussian=False):
     """
     @param L4Overrides (dict)
     Custom parameters for L4
@@ -53,23 +95,32 @@ class PIUNCorticalColumn(object):
     @param locationConfigs (sequence of dicts)
     Parameters for the location modules
     """
+    L4cellCount = 150*16
+    if useGaussian:
+      self.L6aModules = [
+        createRatModule(
+          anchorInputSize=L4cellCount,
+          **config)
+        for config in locationConfigs]
+    else:
+      self.L6aModules = [
+        Superficial2DLocationModule(
+          anchorInputSize=L4cellCount,
+          **config)
+        for config in locationConfigs]
+
     L4Params = {
       "columnCount": 150,
       "cellsPerColumn": 16,
       "basalInputSize": (len(locationConfigs) *
-                         sum(np.prod(config["cellDimensions"])
-                             for config in locationConfigs))
+                         sum(module.numberOfCells()
+                             for module in self.L6aModules))
     }
+
     if L4Overrides is not None:
       L4Params.update(L4Overrides)
-
     self.L4 = ApicalTiebreakPairMemory(**L4Params)
 
-    self.L6aModules = [
-      Superficial2DLocationModule(
-        anchorInputSize=self.L4.numberOfCells(),
-        **config)
-      for config in locationConfigs]
 
 
   def movementCompute(self, displacement, noiseFactor = 0, moduleNoiseFactor = 0):
@@ -114,6 +165,7 @@ class PIUNCorticalColumn(object):
     inputParams = {
       "activeColumns": activeMinicolumns,
       "basalInput": self.getLocationRepresentation(),
+      "basalGrowthCandidates": self.getLearnableLocationRepresentation(),
       "learn": learn
     }
     self.L4.compute(**inputParams)
@@ -168,6 +220,39 @@ class PIUNCorticalColumn(object):
     return activeCells
 
 
+  def getLearnableLocationRepresentation(self):
+    """
+    Get the cells in the location layer that should be associated with the
+    sensory input layer representation. In some models, this is identical to the
+    active cells. In others, it's a subset.
+    """
+    learnableCells = np.array([], dtype="uint32")
+
+    totalPrevCells = 0
+    for module in self.L6aModules:
+      learnableCells = np.append(learnableCells,
+                                 module.getLearnableCells() + totalPrevCells)
+      totalPrevCells += module.numberOfCells()
+
+    return learnableCells
+
+
+  def getSensoryAssociatedLocationRepresentation(self):
+    """
+    Get the location cells in the location layer that were driven by the input
+    layer (or, during learning, were associated with this input.)
+    """
+    cells = np.array([], dtype="uint32")
+
+    totalPrevCells = 0
+    for module in self.L6aModules:
+      cells = np.append(cells,
+                        module.sensoryAssociatedCells + totalPrevCells)
+      totalPrevCells += module.numberOfCells()
+
+    return cells
+
+
 
 class PIUNExperiment(object):
   """
@@ -202,10 +287,12 @@ class PIUNExperiment(object):
     self.numActiveMinicolumns = numActiveMinicolumns
 
     # Use these for classifying SDRs and for testing whether they're correct.
-    self.locationRepresentations = {
-      # Example:
-      # (objectName, featureIndex): [0, 26, 54, 77, 101, ...]
-    }
+    # Allow storing multiple representations, in case the experiment learns
+    # multiple points on a single feature. (We could switch to indexing these by
+    # objectName, featureIndex, coordinates.)
+    # Example:
+    # (objectName, featureIndex): [(0, 26, 54, 77, 101, ...), ...]
+    self.locationRepresentations = defaultdict(list)
     self.inputRepresentations = {
       # Example:
       # (objectName, featureIndex, featureName): [0, 26, 54, 77, 101, ...]
@@ -276,22 +363,18 @@ class PIUNExperiment(object):
       for iFeature, feature in enumerate(objectDescription["features"]):
         self._move(feature, randomLocation=randomLocation, useNoise=useNoise)
         featureSDR = self.features[feature["name"]]
-        for _ in xrange(1):
-          self._sense(featureSDR, learn=True, waitForSettle=False)
+        self._sense(featureSDR, learn=True, waitForSettle=False)
 
-        if (objectDescription["name"], iFeature) not in self.locationRepresentations:
-          self.locationRepresentations[(objectDescription["name"], iFeature)] = []
-
+        locationRepresentation = self.column.getSensoryAssociatedLocationRepresentation()
         self.locationRepresentations[(objectDescription["name"],
-                                      iFeature)].append(
-                                        self.column.getLocationRepresentation())
+                                      iFeature)].append(locationRepresentation)
         self.inputRepresentations[(objectDescription["name"],
                                    iFeature, feature["name"])] = (
-                                     self.column.getSensoryRepresentation())
+                                     self.column.L4.getWinnerCells())
+
+        self.representationSet.add(tuple(locationRepresentation))
 
     self.learnedObjects.append(objectDescription)
-
-    self.representationSet.add(tuple(self.column.getLocationRepresentation()))
 
 
   def inferObjectWithRandomMovements(self,
@@ -342,13 +425,19 @@ class PIUNExperiment(object):
         featureSDR = self.features[feature["name"]]
         self._sense(featureSDR, learn=False, waitForSettle=False)
 
-        representation = self.column.getLocationRepresentation()
+        # Use the sensory-activated cells to detect whether the object has been
+        # recognized. In some models, this set of cells is equivalent to the
+        # active cells. In others, a set of cells around the sensory-activated
+        # cells become active. In either case, if these sensory-activated cells
+        # are correct, it implies that the input layer's representation is
+        # classifiable -- the location layer just correctly classified it.
+        representation = self.column.getSensoryAssociatedLocationRepresentation()
 
         target_representations = set(np.concatenate(
           self.locationRepresentations[
             (objectDescription["name"], iFeature)]))
         inferred = (set(representation) <=
-          target_representations)
+                    target_representations)
 
         if not inferred and tuple(representation) in self.representationSet:
           # We have converged to an incorrect representation - declare failure.

--- a/projects/union_path_integration/ambiguity_index.py
+++ b/projects/union_path_integration/ambiguity_index.py
@@ -1,0 +1,316 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+A metric for the ambiguity of each sensory input.
+"""
+
+import itertools
+import math
+import numbers
+
+import numpy as np
+
+
+def choose(n, k):
+  """
+  Computes "n choose k". This can handle higher values than
+  scipy.special.binom().
+  """
+  if isinstance(k, numbers.Number):
+    return _choose(n, k)
+  else:
+    return np.array([_choose(n, k2) for k2 in k])
+
+
+def _choose(n, k):
+  k = np.minimum(k, n - k)
+  return (np.product(np.arange(n-k+1, n+1, dtype="float128")) /
+          np.product(np.arange(1, k+1, dtype="float128")))
+
+
+class BinomialDistribution(object):
+  """
+  Given a coin with P(Heads=p), flip it n times.
+  What's the probability of getting k heads?
+  """
+
+  def __init__(self, n, p, cache=False):
+    self.n = n
+    self.p = p
+    self.possibleValues = xrange(0, n+1)
+    self.cache = cache
+    if self.cache:
+      self._cache()
+
+  def _cache(self):
+    self._cachedPmf = self._pmf(np.arange(self.n + 1))
+    self._cachedCdf = np.zeros(self.n + 1)
+    for k in xrange(self.n + 1):
+      self._cachedCdf[k:] += self._cachedPmf[k]
+
+  def _pmf(self, k):
+    return (choose(self.n, k)*
+            np.power(self.p, k)*
+            np.power(1. - self.p, self.n - k))
+
+  def pmf(self, k):
+    if self.cache:
+      withinBounds = (k >= 0) & (k <= self.n)
+      k2 = np.where(withinBounds, k, 0)
+      return np.where(withinBounds, self._cachedPmf(k2))
+    else:
+      return self._pmf(k)
+
+  def _cdf(self, k):
+    return np.sum(self._pmf(np.arange(k+1)))
+
+  def cdf(self, k):
+    if self.cache:
+      notNegative = k >= 0
+      notGtN = k <= self.n
+      withinBounds = notNegative & notGtN
+      k2 = np.where(withinBounds, k, 0)
+      return np.where(notNegative, np.where(notGtN, self._cachedCdf[k2],
+                                            1.),
+                      0.)
+    else:
+      if isinstance(k, numbers.Number):
+        return self._cdf(k)
+      else:
+        return np.array([self._cdf(k2) for k2 in k])
+
+
+class SampleMinimumDistribution(object):
+  """
+  Sample a random variable.
+  What is the probability that the lowest sample is k?
+  """
+  def __init__(self, numSamples, distribution):
+    self.numSamples = numSamples
+    self.distribution = distribution
+    self.possibleValues = distribution.possibleValues
+
+  def pmf(self, k):
+    return self.cdf(k) - self.cdf(k-1)
+
+  def cdf(self, k):
+    return 1 - np.power(1 - self.distribution.cdf(k), self.numSamples)
+
+
+def getExpectedValue(distribution):
+  """
+  Calculates E[X] where X is a distribution.
+  """
+  k = np.array(distribution.possibleValues)
+  return np.sum(k * distribution.pmf(k))
+
+
+def findBinomialNsWithExpectedSampleMinimum(desiredValuesSorted, p, numSamples, nMax):
+  """
+  For each desired value, find an approximate n for which the sample minimum
+  has a expected value equal to this value.
+
+  For each value, find an adjacent pair of n values whose expected sample minima
+  are below and above the desired value, respectively, and return a
+  linearly-interpolated n between these two values.
+
+  @param p (float)
+  The p if the binomial distribution.
+
+  @param numSamples (int)
+  The number of samples in the sample minimum distribution.
+
+  @return
+  A list of results. Each result contains
+    (interpolated_n, lower_value, upper_value).
+  where each lower_value and upper_value are the expected sample minimum for
+  floor(interpolated_n) and ceil(interpolated_n)
+  """
+
+  # mapping from n -> expected value
+  actualValues = [
+    getExpectedValue(
+      SampleMinimumDistribution(numSamples,
+                                BinomialDistribution(n, p, cache=True)))
+    for n in xrange(nMax + 1)]
+
+  results = []
+
+  n = 0
+
+  for desiredValue in desiredValuesSorted:
+    while n + 1 <= nMax and actualValues[n + 1] < desiredValue:
+      n += 1
+
+    if n + 1 > nMax:
+      break
+
+    interpolated = n + ((desiredValue - actualValues[n]) /
+                        (actualValues[n+1] - actualValues[n]))
+    result = (interpolated, actualValues[n], actualValues[n + 1])
+    results.append(result)
+
+  return results
+
+
+def findBinomialNsWithLowerBoundSampleMinimum(confidence, desiredValuesSorted,
+                                              p, numSamples, nMax):
+  """
+  For each desired value, find an approximate n for which the sample minimum
+  has a probabilistic lower bound equal to this value.
+
+  For each value, find an adjacent pair of n values whose lower bound sample
+  minima are below and above the desired value, respectively, and return a
+  linearly-interpolated n between these two values.
+
+  @param confidence (float)
+  For the probabilistic lower bound, this specifies the probability. If this is
+  0.8, that means that there's an 80% chance that the sample minimum is >= the
+  desired value, and 20% chance that it's < the desired value.
+
+  @param p (float)
+  The p if the binomial distribution.
+
+  @param numSamples (int)
+  The number of samples in the sample minimum distribution.
+
+  @return
+  A list of results. Each result contains
+    (interpolated_n, lower_value, upper_value).
+  where each lower_value and upper_value are the probabilistic lower bound
+  sample minimum for floor(interpolated_n) and ceil(interpolated_n)
+  respectively.
+   ...]
+  """
+
+  def P(n, numOccurrences):
+    """
+    Given n, return probability than the sample minimum is >= numOccurrences
+    """
+    return 1 - SampleMinimumDistribution(numSamples, BinomialDistribution(n, p)).cdf(
+      numOccurrences - 1)
+
+  results = []
+
+  n = 0
+
+  for desiredValue in desiredValuesSorted:
+    while n + 1 <= nMax and P(n + 1, desiredValue) < confidence:
+      n += 1
+
+    if n + 1 > nMax:
+      break
+
+    left = P(n, desiredValue)
+    right = P(n + 1, desiredValue)
+
+    interpolated = n + ((confidence - left) /
+                        (right - left))
+    result = (interpolated, left, right)
+    results.append(result)
+
+  return results
+
+
+def generateExpectedList(numUniqueFeatures, numLocationsPerObject, maxNumObjects):
+  """
+  Metric: How unique is each object's most unique feature? Calculate the
+  expected number of occurrences of an object's most unique feature.
+  """
+  # We're choosing a location, checking its feature, and checking how many
+  # *other* occurrences there are of this feature. So we check n - 1 locations.
+  maxNumOtherLocations = maxNumObjects*10 - 1
+
+  results = zip(itertools.count(1),
+                findBinomialNsWithExpectedSampleMinimum(
+                  itertools.count(1), 1./numUniqueFeatures, numLocationsPerObject,
+                  maxNumOtherLocations))
+
+  finalResults = [(numOtherLocations, interpolatedN / numLocationsPerObject)
+                  for numOtherLocations, (interpolatedN, _, _) in results]
+
+  return [(0, 0.)] + finalResults
+
+
+def generateLowerBoundList(confidence, numUniqueFeatures, numLocationsPerObject,
+                           maxNumObjects):
+  """
+  Metric: How unique is each object's most unique feature? Calculate the
+  probabilistic lower bound for the number of occurrences of an object's most
+  unique feature. For example, if confidence is 0.8, the tick "3" will be placed
+  at the point where 80% of objects are completely composed of features with 3
+  or more total occurrences, and 20% of objects have at least one feature that
+  has 2 or fewer total occurrences.
+  """
+  # We're choosing a location, checking its feature, and checking how many
+  # *other* occurrences there are of this feature. So we check n - 1 locations.
+  maxNumOtherLocations = maxNumObjects*10 - 1
+
+  results = zip(itertools.count(1),
+                findBinomialNsWithLowerBoundSampleMinimum(
+                  confidence,
+                  itertools.count(1), 1./numUniqueFeatures, numLocationsPerObject,
+                  maxNumOtherLocations))
+
+  finalResults = [(numOtherLocations, interpolatedN / numLocationsPerObject)
+                  for numOtherLocations, (interpolatedN, _, _) in results]
+
+  return finalResults
+
+
+def getTotalExpectedOccurrencesTicks_2_5(ticks):
+  """
+  Extract a set of tick locations and labels. The input ticks are assumed to
+  mean "How many *other* occurrences are there of the sensed feature?" but we
+  want to show how many *total* occurrences there are. So we add 1.
+
+  We label tick 2, and then 5, 10, 15, 20, ...
+
+  @param ticks
+  A list of ticks, typically calculated by one of the above generate*List functions.
+  """
+  locs = [loc
+          for label, loc in ticks]
+  labels = [(str(label + 1) if
+             (label + 1 == 2
+             or (label+1) % 5 == 0)
+             else "")
+            for label, loc in ticks]
+  return locs, labels
+
+
+
+# Result of generateExpectedList(100, 10, 175)
+numOtherOccurrencesOfMostUniqueFeature_expected_100features_10locationsPerObject = [(0, 0.), (1, 35.045167030044915), (2, 51.216815324993732), (3, 65.992011877006846), (4, 80.035086889843299), (5, 93.606591830738111), (6, 106.84133218518113), (7, 119.81991111184459), (8, 132.59509350322159), (9, 145.20366899818202), (10, 157.67250545353863), (11, 170.02193806774264)]
+
+# Result of generateLowerBoundList(100, 10, 800)
+numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject = [(1, 37.945711986980281298), (2, 56.949050730340841475), (3, 73.613153481567207309), (4, 89.151770000095628528), (5, 103.99430588840699859), (6, 118.35178815706850657), (7, 132.34606437289453924), (8, 146.05527446633717879), (9, 159.53297434899399285), (10, 172.81778839309870084), (11, 185.93870238076113069), (12, 198.91800794416756371), (13, 211.77345422740526286), (14, 224.5192892475029286), (15, 237.16727926124247836), (16, 249.72717145985129587), (17, 262.20721393780454658), (18, 274.61448911011742019), (19, 286.95503748208463807), (20, 299.23409113244846178), (21, 311.45628337016557993), (22, 323.6256546907131344), (23, 335.74582776301934292), (24, 347.81997350922715531), (25, 359.85100720265628849), (26, 371.84147764836780187), (27, 383.79371226466881223), (28, 395.70988089399994073), (29, 407.59188220054527277), (30, 419.44150867845537373), (31, 431.26033550021001997), (32, 443.04987285220273052), (33, 454.81147221081922999), (34, 466.54645370480893457), (35, 478.25594059309893721), (36, 489.94104056621675652), (37, 501.60274579810184209), (38, 513.24207330833960572), (39, 524.85983580646023339), (40, 536.45688598866419194), (41, 548.03399620404267384), (42, 559.59188451926507002), (43, 571.13127973254151287), (44, 582.65278616200897643), (45, 594.15701982627148642), (46, 605.64456035814804691), (47, 617.11593961883466847), (48, 628.57170193793512336), (49, 640.0123014000995455), (50, 651.43823892632214934), (51, 662.84992186514829277), (52, 674.24777851463038131), (53, 685.63220582033170314), (54, 697.00357217790089892), (55, 708.36228952392155422), (56, 719.70863491784629157), (57, 731.04300093527000082), (58, 742.36565691894599961), (59, 753.67691947970915894), (60, 764.97708472053819151), (61, 776.26642987792063488), (62, 787.54521479547484686), (63, 798.81368324995423569)]
+
+
+# Result of generateList(200, 10, 175)
+ticks_expectedNumOtherOccurrencesOfMostUniqueFeature_200_features_10_locationsPerObject = [(0, 0.), (1, 70.230862035193098), (2, 102.6060368217816), (3, 132.18080065565022), (4, 160.28751037290095)]
+
+
+
+if __name__ == "__main__":
+  # print generateExpectedList(100, 10, 100)
+  print generateLowerBoundList(0.8, 100, 10, 800)

--- a/projects/union_path_integration/convergence_simulation.py
+++ b/projects/union_path_integration/convergence_simulation.py
@@ -71,7 +71,7 @@ def generateObjects(numObjects, featuresPerObject, objectWidth, numFeatures):
   return objects
 
 
-def doExperiment(cellsPerAxis,
+def doExperiment(locationModuleWidth,
                  cellCoordinateOffsets,
                  numObjects,
                  featuresPerObject,
@@ -88,7 +88,7 @@ def doExperiment(cellsPerAxis,
   Learn a set of objects. Then try to recognize each object. Output an
   interactive visualization.
 
-  @param cellsPerAxis (int)
+  @param locationModuleWidth (int)
   The cell dimensions of each module
 
   @param cellCoordinateOffsets (sequence)
@@ -113,7 +113,7 @@ def doExperiment(cellsPerAxis,
     orientation = (float(i) * perModRange) + (perModRange / 2.0)
 
     locationConfigs.append({
-      "cellsPerAxis": cellsPerAxis,
+      "cellsPerAxis": locationModuleWidth,
       "scale": scale,
       "orientation": orientation,
       "cellCoordinateOffsets": cellCoordinateOffsets,
@@ -296,7 +296,7 @@ if __name__ == "__main__":
 
   runMultiprocessNoiseExperiment(
     args.resultName, args.repeat, args.numWorkers, args.appendResults,
-    cellsPerAxis=args.locationModuleWidth,
+    locationModuleWidth=args.locationModuleWidth,
     cellCoordinateOffsets=cellCoordinateOffsets,
     numObjects=args.numObjects,
     featuresPerObject=10,

--- a/projects/union_path_integration/gaussian_simulation.py
+++ b/projects/union_path_integration/gaussian_simulation.py
@@ -88,9 +88,6 @@ def doExperiment(numObjects,
   """
   Learn a set of objects. Then try to recognize each object. Output an
   interactive visualization.
-
-  @param cellsPerAxis (int)
-  The cell dimensions of each module
   """
   if not os.path.exists("traces"):
     os.makedirs("traces")

--- a/projects/union_path_integration/gaussian_simulation.py
+++ b/projects/union_path_integration/gaussian_simulation.py
@@ -20,7 +20,8 @@
 # ----------------------------------------------------------------------
 
 """
-Convergence simulations for abstract objects.
+Recognition experiments for abstract objects, using a gaussian bump grid
+cell module model.
 """
 
 import argparse
@@ -71,9 +72,7 @@ def generateObjects(numObjects, featuresPerObject, objectWidth, numFeatures):
   return objects
 
 
-def doExperiment(cellsPerAxis,
-                 cellCoordinateOffsets,
-                 numObjects,
+def doExperiment(numObjects,
                  featuresPerObject,
                  objectWidth,
                  numFeatures,
@@ -83,16 +82,15 @@ def doExperiment(cellsPerAxis,
                  moduleNoiseFactor,
                  numModules,
                  thresholds,
-                 anchoringMethod = "narrowing"):
+                 inverseReadoutResolution,
+                 enlargeModuleFactor,
+                 bumpOverlapMethod):
   """
   Learn a set of objects. Then try to recognize each object. Output an
   interactive visualization.
 
   @param cellsPerAxis (int)
   The cell dimensions of each module
-
-  @param cellCoordinateOffsets (sequence)
-  The "cellCoordinateOffsets" parameter for each module
   """
   if not os.path.exists("traces"):
     os.makedirs("traces")
@@ -113,19 +111,20 @@ def doExperiment(cellsPerAxis,
     orientation = (float(i) * perModRange) + (perModRange / 2.0)
 
     locationConfigs.append({
-      "cellsPerAxis": cellsPerAxis,
-      "scale": scale,
-      "orientation": orientation,
-      "cellCoordinateOffsets": cellCoordinateOffsets,
-      "activationThreshold": 8,
-      "initialPermanence": 1.0,
-      "connectedPermanence": 0.5,
-      "learningThreshold": 8,
-      "sampleSize": 10,
-      "permanenceIncrement": 0.1,
-      "permanenceDecrement": 0.0,
-      "anchoringMethod": anchoringMethod,
+        "scale": scale,
+        "orientation": orientation,
+        "activationThreshold": 8,
+        "initialPermanence": 1.0,
+        "connectedPermanence": 0.5,
+        "learningThreshold": 8,
+        "sampleSize": 10,
+        "permanenceIncrement": 0.1,
+        "permanenceDecrement": 0.0,
+        "inverseReadoutResolution": inverseReadoutResolution,
+        "enlargeModuleFactor": enlargeModuleFactor,
+        "bumpOverlapMethod": bumpOverlapMethod,
     })
+
   l4Overrides = {
     "initialPermanence": 1.0,
     "activationThreshold": thresholds,
@@ -135,7 +134,8 @@ def doExperiment(cellsPerAxis,
     "cellsPerColumn": 16,
   }
 
-  column = PIUNCorticalColumn(locationConfigs, L4Overrides=l4Overrides)
+  column = PIUNCorticalColumn(locationConfigs, L4Overrides=l4Overrides,
+                              useGaussian=True)
   exp = PIUNExperiment(column, featureNames=features,
                        numActiveMinicolumns=10,
                        noiseFactor=noiseFactor,
@@ -146,15 +146,13 @@ def doExperiment(cellsPerAxis,
 
   filename = os.path.join(
       SCRIPT_DIR,
-      "traces/{}-points-{}-cells-{}-objects-{}-feats.html".format(
-          len(cellCoordinateOffsets)**2, exp.column.L6aModules[0].numberOfCells(),
-          numObjects, numFeatures)
+      "traces/{}-resolution-{}-modules-{}-objects-{}-feats.html".format(
+          inverseReadoutResolution, numModules, numObjects, numFeatures)
   )
   rawFilename = os.path.join(
       SCRIPT_DIR,
-      "traces/{}-points-{}-cells-{}-objects-{}-feats.trace".format(
-          len(cellCoordinateOffsets)**2, exp.column.L6aModules[0].numberOfCells(),
-          numObjects, numFeatures)
+      "traces/{}-resolution-{}-modules-{}-objects-{}-feats.trace".format(
+          inverseReadoutResolution, numModules, numObjects, numFeatures)
   )
 
   assert not (useTrace and useRawTrace), "Cannot use both --trace and --rawTrace"
@@ -259,10 +257,10 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument("--numObjects", type=int, nargs="+", required=True)
   parser.add_argument("--numUniqueFeatures", type=int, required=True)
-  parser.add_argument("--locationModuleWidth", type=int, required=True)
-  parser.add_argument("--coordinateOffsetWidth", type=int, default=2)
   parser.add_argument("--noiseFactor", type=float, nargs="+", required=False, default = 0)
   parser.add_argument("--moduleNoiseFactor", type=float, nargs="+", required=False, default=0)
+  parser.add_argument("--inverseReadoutResolution", type=float, default=3)
+  parser.add_argument("--enlargeModuleFactor", type=float, nargs="+", required=False, default=1.0)
   parser.add_argument("--useTrace", action="store_true")
   parser.add_argument("--useRawTrace", action="store_true")
   parser.add_argument("--numModules", type=int, nargs="+", default=[20])
@@ -271,19 +269,13 @@ if __name__ == "__main__":
     help=(
       "The TM prediction threshold. Defaults to int((numModules+1)*0.8)."
       "Set to 0 for the threshold to match the number of modules."))
-  parser.add_argument("--anchoringMethod", type = str, default="corners")
+  parser.add_argument("--bumpOverlapMethod", type = str, default="probabilistic")
   parser.add_argument("--resultName", type = str, default="results.json")
   parser.add_argument("--repeat", type=int, default=1)
   parser.add_argument("--appendResults", action="store_true")
   parser.add_argument("--numWorkers", type=int, default=cpu_count())
 
   args = parser.parse_args()
-
-  numOffsets = args.coordinateOffsetWidth
-  cellCoordinateOffsets = tuple([i * (0.998 / (numOffsets-1)) + 0.001 for i in xrange(numOffsets)])
-
-  if "both" in args.anchoringMethod:
-    args.anchoringMethod = ["narrowing", "corners"]
 
 
   # Use a fixed seed unless we're appending to a file. (In that case we're
@@ -296,8 +288,6 @@ if __name__ == "__main__":
 
   runMultiprocessNoiseExperiment(
     args.resultName, args.repeat, args.numWorkers, args.appendResults,
-    cellsPerAxis=args.locationModuleWidth,
-    cellCoordinateOffsets=cellCoordinateOffsets,
     numObjects=args.numObjects,
     featuresPerObject=10,
     objectWidth=4,
@@ -308,5 +298,7 @@ if __name__ == "__main__":
     moduleNoiseFactor=args.moduleNoiseFactor,
     numModules=args.numModules,
     thresholds=args.thresholds,
-    anchoringMethod=args.anchoringMethod,
+    inverseReadoutResolution=args.inverseReadoutResolution,
+    enlargeModuleFactor=args.enlargeModuleFactor,
+    bumpOverlapMethod=args.bumpOverlapMethod,
   )

--- a/projects/union_path_integration/infer_hand_crafted_objects.py
+++ b/projects/union_path_integration/infer_hand_crafted_objects.py
@@ -69,7 +69,7 @@ OBJECTS = [
 ]
 
 
-def doExperiment(cellDimensions, cellCoordinateOffsets):
+def doPointsExperiment(cellDimensions, cellCoordinateOffsets):
   """
   Learn a set of objects. Then try to recognize each object. Output an
   interactive visualization.
@@ -92,13 +92,26 @@ def doExperiment(cellDimensions, cellCoordinateOffsets):
       orientation = random.choice([orientation, -orientation])
 
       locationConfigs.append({
-        "cellDimensions": cellDimensions,
-        "moduleMapDimensions": (scale, scale),
+        "cellsPerAxis": cellDimensions[0],
+        "scale": scale,
         "orientation": orientation,
+        "activationThreshold": 8,
+        "initialPermanence": 1.0,
+        "connectedPermanence": 0.5,
+        "learningThreshold": 8,
+        "sampleSize": 10,
+        "permanenceIncrement": 0.1,
+        "permanenceDecrement": 0.0,
         "cellCoordinateOffsets": cellCoordinateOffsets,
       })
 
-  column = PIUNCorticalColumn(locationConfigs)
+  L4Overrides = {
+    "activationThreshold": 15,
+    "minThreshold": 15,
+    "initialPermanence": 1.0,
+  }
+
+  column = PIUNCorticalColumn(locationConfigs, L4Overrides, useGaussian=False)
   exp = PIUNExperiment(column, featureNames=("A", "B"))
 
   for objectDescription in OBJECTS:
@@ -117,12 +130,65 @@ def doExperiment(cellDimensions, cellCoordinateOffsets):
 
 
 
+def doGaussianExperiment(inverseReadoutResolution):
+  """
+  Learn a set of objects. Then try to recognize each object. Output an
+  interactive visualization.
+
+  @param cellDimensions (pair)
+  The cell dimensions of each module
+  """
+  if not os.path.exists("traces"):
+    os.makedirs("traces")
+
+  locationConfigs = []
+  for i in xrange(5):
+    scale = 10.0 * (math.sqrt(2) ** i)
+
+    for _ in xrange(4):
+      orientation = np.radians(random.gauss(7.5, 7.5))
+      orientation = random.choice([orientation, -orientation])
+
+      locationConfigs.append({
+        "scale": scale,
+        "inverseReadoutResolution": inverseReadoutResolution,
+        "orientation": orientation,
+        "activationThreshold": 8,
+        "initialPermanence": 1.0,
+        "connectedPermanence": 0.5,
+        "learningThreshold": 8,
+        "sampleSize": 10,
+        "permanenceIncrement": 0.1,
+        "permanenceDecrement": 0.0,
+      })
+
+  L4Overrides = {
+    "activationThreshold": 15,
+    "minThreshold": 15,
+    "initialPermanence": 1.0,
+  }
+
+  column = PIUNCorticalColumn(locationConfigs, L4Overrides, useGaussian=True)
+  exp = PIUNExperiment(column, featureNames=("A", "B"))
+
+  for objectDescription in OBJECTS:
+    exp.learnObject(objectDescription)
+
+  filename = "traces/gaussian-{}-resolution.html".format(
+    np.prod(inverseReadoutResolution))
+
+  with io.open(filename, "w", encoding="utf8") as fileOut:
+    with trace(fileOut, exp, includeSynapses=True):
+      print "Logging to", filename
+      for objectDescription in OBJECTS:
+        succeeded = exp.inferObjectWithRandomMovements(objectDescription)
+        if not succeeded:
+          print 'Failed to infer object "{}"'.format(objectDescription["name"])
+
+
+
 if __name__ == "__main__":
-  doExperiment(cellDimensions=(5, 5),
-               cellCoordinateOffsets=(0.5,))
+  doPointsExperiment(cellDimensions=(10, 10),
+                     cellCoordinateOffsets=(0.05, 0.5, 0.95))
 
-  doExperiment(cellDimensions=(5, 5),
-               cellCoordinateOffsets=(0.05, 0.5, 0.95))
-
-  doExperiment(cellDimensions=(10, 10),
-               cellCoordinateOffsets=(0.05, 0.5, 0.95))
+  doGaussianExperiment(inverseReadoutResolution=8)

--- a/projects/union_path_integration/plot_gaussian_capacity.py
+++ b/projects/union_path_integration/plot_gaussian_capacity.py
@@ -1,0 +1,343 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Plot capacity charts."""
+
+from collections import defaultdict
+import json
+import math
+import os
+import itertools
+
+import matplotlib.pyplot as plt
+import matplotlib.lines
+import numpy as np
+
+import ambiguity_index
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+CHART_DIR = os.path.join(CWD, "charts")
+
+
+def varyResolution_varyNumModules(inFilenames, outFilename,
+                                  resolutions=(2, 3, 4),
+                                  moduleCounts=(6, 12, 18,),
+                                  maxNumObjectsByResolution={}):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      numModules = exp[0]["numModules"]
+      numObjects = exp[0]["numObjects"]
+      resolution = exp[0]["inverseReadoutResolution"]
+
+      failed = exp[1].get("null", 0)
+      allResults[(numModules, resolution)][numObjects].append(
+        1.0 - (float(failed) / float(numObjects)))
+
+  for resolution, color in zip(resolutions, colors):
+    for numModules, marker, markerSize in zip(moduleCounts, markers, markerSizes):
+      resultsByNumObjects = allResults[(numModules, resolution)]
+      expResults = [(numObjects, sum(results) / len(results))
+                    for numObjects, results in resultsByNumObjects.iteritems()
+                    if resolution not in maxNumObjectsByResolution
+                    or numObjects <= maxNumObjectsByResolution[resolution]]
+
+      x = []
+      y = []
+      for i, j in sorted(expResults):
+        x.append(i)
+        y.append(j)
+
+      ax1.plot(
+        x, y, "{}-".format(marker), color=color, linewidth=1, markersize=markerSize
+      )
+
+
+  leg = ax1.legend(loc="upper right", title=" Readout bins per axis:",
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=resolutions)
+  ax1.add_artist(leg)
+
+  leg = ax1.legend(loc="center right", title="Number of modules:",
+                   bbox_to_anchor=(0.99, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=moduleCounts)
+
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Recognition accuracy after many sensations")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+
+def varyModuleSize_varyResolution(inFilenames, outFilename,
+                                  scalingFactors=[1, 2], resolutions=(2, 3, 4),
+                                  maxNumObjectsByParams={}):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      enlargeModuleFactor = exp[0]["enlargeModuleFactor"]
+      numObjects = exp[0]["numObjects"]
+      resolution = exp[0]["inverseReadoutResolution"]
+
+      failed = exp[1].get("null", 0)
+      allResults[(enlargeModuleFactor, resolution)][numObjects].append(
+        1.0 - (float(failed) / float(numObjects)))
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+  for scalingFactor, color in zip(scalingFactors, colors):
+    for resolution, marker, markerSize in zip(resolutions, markers, markerSizes):
+      resultsByNumObjects = allResults[(scalingFactor, resolution)]
+      expResults = [(numObjects, sum(results) / len(results))
+                     for numObjects, results in resultsByNumObjects.iteritems()
+                    if (scalingFactor, resolution) not in maxNumObjectsByParams
+                    or numObjects <= maxNumObjectsByParams[(scalingFactor, resolution)]]
+
+      x = []
+      y = []
+      for i, j in sorted(expResults):
+        x.append(i)
+        y.append(j)
+
+      ax1.plot(
+        x, y, "{}-".format(marker), color=color, linewidth=1, markersize=markerSize
+      )
+
+
+  # Carefully use whitespace in title to shift the entries in the legend to
+  # align with the next legend.
+  leg = ax1.legend(loc="upper right", title="Bump size:       ",
+                   # bbox_to_anchor=(0.98, 1.0),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=["$ \\sigma = \\sigma_{rat} $",
+                           "$ \\sigma = \\sigma_{rat} / 2.0 $"])
+
+  ax1.add_artist(leg)
+
+
+  leg = ax1.legend(loc="center right", title="Readout bins per axis:",
+                   bbox_to_anchor=(1.0, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=["$ \\frac{\\sigma_{rat}}{\\sigma} * 2 $ ",
+                           "$ \\frac{\\sigma_{rat}}{\\sigma} * 3 $ ",
+                           "$ \\frac{\\sigma_{rat}}{\\sigma} * 4 $ "])
+
+  ax1.set_xlim(ax1.get_xlim()[0], 400)
+  print ax1.get_xlim()
+
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Recognition accuracy after many sensations")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+
+def varyModuleSize_varyNumModules(inFilenames, outFilename,
+                                  scalingFactors=[1, 2, 3],
+                                  moduleCounts=(6,12,18),
+                                  maxNumObjectsByParams={}):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      enlargeModuleFactor = exp[0]["enlargeModuleFactor"]
+      numObjects = exp[0]["numObjects"]
+      numModules = exp[0]["numModules"]
+
+      failed = exp[1].get("null", 0)
+      allResults[(enlargeModuleFactor, numModules)][numObjects].append(
+        1.0 - (float(failed) / float(numObjects)))
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+  # Optional: swap axes
+  # ax1.xaxis.tick_top()
+  # ax1.xaxis.set_label_position('top')
+  # ax2.xaxis.tick_bottom()
+  # ax2.xaxis.set_label_position('bottom')
+
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+  for scalingFactor, color in zip(scalingFactors, colors):
+    for numModules, marker, markerSize in zip(moduleCounts, markers, markerSizes):
+      resultsByNumObjects = allResults[(scalingFactor, numModules)]
+      expResults = [(numObjects, sum(results) / len(results))
+                     for numObjects, results in resultsByNumObjects.iteritems()
+                    if (scalingFactor, numModules) not in maxNumObjectsByParams
+                    or numObjects <= maxNumObjectsByParams[(scalingFactor, numModules)]]
+
+      x = []
+      y = []
+      for i, j in sorted(expResults):
+        x.append(i)
+        y.append(j)
+
+      ax1.plot(
+        x, y, "{}-".format(marker), color=color, linewidth=1, markersize=markerSize
+      )
+
+  # Carefully use whitespace in title to shift the entries in the legend to
+  # align with the next legend.
+  leg = ax1.legend(loc="upper right", title="Module size:       ",
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=["rat", "rat * 2", "rat * 3"])
+  ax1.add_artist(leg)
+
+
+  leg = ax1.legend(loc="center right", title="Number of modules:",
+                   bbox_to_anchor=(1.0, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=moduleCounts)
+
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Recognition accuracy after many sensations")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+
+if __name__ == "__main__":
+  varyResolution_varyNumModules(
+    ["results/gaussian_varyNumModules_100_feats_2_resolution.json",
+     "results/gaussian_varyNumModules_100_feats_3_resolution.json",
+     "results/gaussian_varyNumModules_100_feats_4_resolution.json"],
+    "capacity100_gaussian_varyResolution_varyNumModules.pdf",
+    maxNumObjectsByResolution={
+      4: 160,
+      3: 130,
+    }
+  )
+
+  # varyModuleSize_varyResolution(
+  #   [],
+  #   "capacity100_gaussian_varyModuleSize_varyResolution.pdf",
+  #   maxNumObjectsByParams={
+  #     (1.0, 4): 150,
+  #   }
+  # )
+
+  varyModuleSize_varyNumModules(
+    ["results/varyModuleSize_100_feats_1_enlarge.json",
+     "results/varyModuleSize_100_feats_2_enlarge.json",
+     "results/varyModuleSize_100_feats_3_enlarge.json"],
+    "capacity100_gaussian_varyModuleSize_varyNumModules.pdf",
+    maxNumObjectsByParams={
+      # (1.0, 4): 150,
+    }
+  )

--- a/projects/union_path_integration/plot_gaussian_convergence.py
+++ b/projects/union_path_integration/plot_gaussian_convergence.py
@@ -1,0 +1,386 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Plot recognition time charts."""
+
+from collections import defaultdict
+import json
+import os
+
+import ambiguity_index
+
+import matplotlib.lines
+import matplotlib.pyplot as plt
+import numpy as np
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+CHART_DIR = os.path.join(CWD, "charts")
+
+
+
+def varyResolution_varyNumModules(inFilenames, outFilename,
+                                  resolutions=(2, 3, 4),
+                                  moduleCounts=(6, 12, 18,),
+                                  xlim=None):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      numModules = exp[0]["numModules"]
+      numObjects = exp[0]["numObjects"]
+      resolution = exp[0]["inverseReadoutResolution"]
+
+      results = []
+      for numSensationsStr, numOccurrences in exp[1].items():
+        if numSensationsStr == "null":
+          results += [np.inf] * numOccurrences
+        else:
+          results += [int(numSensationsStr)] * numOccurrences
+
+      allResults[(numModules, resolution)][numObjects] += results
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+  for resolution, color in zip(resolutions, colors):
+    for numModules, marker, markerSize in zip(moduleCounts, markers, markerSizes):
+      resultsByNumObjects = allResults[(numModules, resolution)]
+
+      expResults = sorted((numObjects, np.median(results))
+                          for numObjects, results in resultsByNumObjects.iteritems())
+
+      # Results up to the final non-infinite median.
+      lineResults = [(numObjects, median)
+                     for numObjects, median in expResults
+                     if median != np.inf]
+
+      # Results excluding the final non-infinite median.
+      numCircleMarkers = len(lineResults)
+      if len(lineResults) < len(expResults):
+        numCircleMarkers -= 1
+
+      # Results including only the final non-infinite median.
+      lineEndResults = ([lineResults[-1]] if len(lineResults) < len(expResults)
+                        else [])
+
+      ax1.plot([numObjects for numObjects, median in lineResults],
+               [median for numObjects, median in lineResults],
+               "{}-".format(marker), markevery=xrange(numCircleMarkers),
+               color=color, linewidth=1, markersize=markerSize)
+      if len(lineResults) < len(expResults):
+        endNumObjects, endMedian = lineEndResults[-1]
+        ax1.plot([endNumObjects], [endMedian], "x", color=color,
+                 markeredgewidth=markerSize/2, markersize=markerSize*1.5)
+
+  if xlim is not None:
+    ax1.set_xlim(xlim[0], xlim[1])
+  ax1.set_ylim(0, ax1.get_ylim()[1])
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Median # sensations before recognition")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  leg = ax1.legend(loc="upper right", title=" Readout bins per axis:",
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=resolutions)
+  ax1.add_artist(leg)
+
+  leg = ax1.legend(loc="center right", title="Number of modules:",
+                   bbox_to_anchor=(0.99, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=moduleCounts)
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+def varyModuleSize_varyResolution(inFilenames, outFilename,
+                                  enlargeModuleFactors=[1.0, 2.0],
+                                  resolutions=(2, 3, 4),
+                                  xlim=None):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      enlargeModuleFactor = exp[0]["enlargeModuleFactor"]
+      numObjects = exp[0]["numObjects"]
+      resolution = exp[0]["inverseReadoutResolution"]
+
+      results = []
+      for numSensationsStr, numOccurrences in exp[1].items():
+        if numSensationsStr == "null":
+          results += [np.inf] * numOccurrences
+        else:
+          results += [int(numSensationsStr)] * numOccurrences
+
+      allResults[(enlargeModuleFactor, resolution)][numObjects] += results
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+  for resolution, marker, markerSize in zip(resolutions, markers, markerSizes):
+    for enlargeModuleFactor, color in zip(enlargeModuleFactors, colors):
+      resultsByNumObjects = allResults[(enlargeModuleFactor, resolution)]
+
+      expResults = sorted((numObjects, np.median(results))
+                          for numObjects, results in resultsByNumObjects.iteritems())
+
+      # Results up to the final non-infinite median.
+      lineResults = [(numObjects, median)
+                     for numObjects, median in expResults
+                     if median != np.inf]
+
+      # Results excluding the final non-infinite median.
+      numCircleMarkers = len(lineResults)
+      if len(lineResults) < len(expResults):
+        numCircleMarkers -= 1
+
+      # Results including only the final non-infinite median.
+      lineEndResults = ([lineResults[-1]] if len(lineResults) < len(expResults)
+                        else [])
+
+      ax1.plot([numObjects for numObjects, median in lineResults],
+               [median for numObjects, median in lineResults],
+               "{}-".format(marker), markevery=xrange(numCircleMarkers),
+               color=color, linewidth=1, markersize=markerSize)
+      if len(lineResults) < len(expResults):
+        endNumObjects, endMedian = lineEndResults[-1]
+        ax1.plot([endNumObjects], [endMedian], "x", color=color,
+                 markeredgewidth=markerSize/2, markersize=markerSize*1.5)
+
+  if xlim is not None:
+    ax1.set_xlim(xlim[0], xlim[1])
+  ax1.set_ylim(0, ax1.get_ylim()[1])
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Median # sensations before recognition")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  # Carefully use whitespace in title to shift the entries in the legend to
+  # align with the previous legend.
+  leg = ax1.legend(loc="upper right", title="Bump size:       ",
+                   # bbox_to_anchor=(0.98, 1.0),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=["$ \\sigma = \\sigma_{rat} $",
+                           "$ \\sigma = \\sigma_{rat} / 2.0 $"])
+
+  ax1.add_artist(leg)
+
+
+  leg = ax1.legend(loc="center right", title="Readout bins per axis:",
+                   bbox_to_anchor=(1.0, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=["$ \\frac{\\sigma_{rat}}{\\sigma} * 2 $ ",
+                           "$ \\frac{\\sigma_{rat}}{\\sigma} * 3 $ ",
+                           "$ \\frac{\\sigma_{rat}}{\\sigma} * 4 $ "])
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+def varyModuleSize_varyNumModules(inFilenames, outFilename,
+                                  enlargeModuleFactors=[1.0, 2.0, 3.0],
+                                  moduleCounts=(6, 12, 18),
+                                  xlim=None):
+  if not os.path.exists(CHART_DIR):
+    os.makedirs(CHART_DIR)
+
+  allResults = defaultdict(lambda: defaultdict(list))
+
+  for inFilename in inFilenames:
+    with open(inFilename, "r") as f:
+      experiments = json.load(f)
+    for exp in experiments:
+      enlargeModuleFactor = exp[0]["enlargeModuleFactor"]
+      numObjects = exp[0]["numObjects"]
+      numModules = exp[0]["numModules"]
+
+      results = []
+      for numSensationsStr, numOccurrences in exp[1].items():
+        if numSensationsStr == "null":
+          results += [np.inf] * numOccurrences
+        else:
+          results += [int(numSensationsStr)] * numOccurrences
+
+      allResults[(enlargeModuleFactor, numModules)][numObjects] += results
+
+  fig = plt.figure()
+  ax1 = fig.add_subplot(111)
+  ax2 = ax1.twiny()
+  # Optional: swap axes
+  # ax1.xaxis.tick_top()
+  # ax1.xaxis.set_label_position('top')
+  # ax2.xaxis.tick_bottom()
+  # ax2.xaxis.set_label_position('bottom')
+
+  colors = ("C0", "C1", "C2")
+  markers = ("o", "o", "o")
+  markerSizes = (2, 4, 6)
+  for numModules, marker, markerSize in zip(moduleCounts, markers, markerSizes):
+    for enlargeModuleFactor, color in zip(enlargeModuleFactors, colors):
+      resultsByNumObjects = allResults[(enlargeModuleFactor, numModules)]
+
+      expResults = sorted((numObjects, np.median(results))
+                          for numObjects, results in resultsByNumObjects.iteritems())
+
+      # Results up to the final non-infinite median.
+      lineResults = [(numObjects, median)
+                     for numObjects, median in expResults
+                     if median != np.inf]
+
+      # Results excluding the final non-infinite median.
+      numCircleMarkers = len(lineResults)
+      if len(lineResults) < len(expResults):
+        numCircleMarkers -= 1
+
+      # Results including only the final non-infinite median.
+      lineEndResults = ([lineResults[-1]] if len(lineResults) < len(expResults)
+                        else [])
+
+      ax1.plot([numObjects for numObjects, median in lineResults],
+               [median for numObjects, median in lineResults],
+               "{}-".format(marker), markevery=xrange(numCircleMarkers),
+               color=color, linewidth=1, markersize=markerSize)
+      if len(lineResults) < len(expResults):
+        endNumObjects, endMedian = lineEndResults[-1]
+        ax1.plot([endNumObjects], [endMedian], "x", color=color,
+                 markeredgewidth=markerSize/2, markersize=markerSize*1.5)
+
+  if xlim is not None:
+    ax1.set_xlim(xlim[0], xlim[1])
+  ax1.set_ylim(0, ax1.get_ylim()[1])
+  ax1.set_xlabel("# learned objects")
+  ax1.set_ylabel("Median # sensations before recognition")
+  ax2.set_xlabel("Sensory ambiguity index", labelpad=8)
+
+  # Carefully use whitespace in title to shift the entries in the legend to
+  # align with the previous legend.
+  leg = ax1.legend(loc="upper right", title="Module size:       ",
+                   # bbox_to_anchor=(0.98, 1.0),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [], color=color)
+                            for color in colors],
+                   labels=["rat", "rat * 2", "rat * 3"])
+  ax1.add_artist(leg)
+
+
+  leg = ax1.legend(loc="center right", title="Number of modules:",
+                   bbox_to_anchor=(1.0, 0.6),
+                   frameon=False,
+                   handles=[matplotlib.lines.Line2D([], [],
+                                                    marker=marker,
+                                                    markersize=markerSize,
+                                                    color="black")
+                            for marker, markerSize in zip(markers, markerSizes)],
+                   labels=moduleCounts)
+
+  locs, labels = ambiguity_index.getTotalExpectedOccurrencesTicks_2_5(
+      ambiguity_index.numOtherOccurrencesOfMostUniqueFeature_lowerBound80_100features_10locationsPerObject)
+  ax2.set_xticks(locs)
+  ax2.set_xticklabels(labels)
+  ax2.set_xlim(ax1.get_xlim())
+  ax2_color = 'gray'
+  ax2.xaxis.label.set_color(ax2_color)
+  ax2.tick_params(axis='x', colors=ax2_color)
+
+  plt.tight_layout()
+
+  filePath = os.path.join(CHART_DIR, outFilename)
+  print "Saving", filePath
+  plt.savefig(filePath)
+
+
+
+if __name__ == "__main__":
+  varyResolution_varyNumModules(
+    ["results/gaussian_varyNumModules_100_feats_2_resolution.json",
+     "results/gaussian_varyNumModules_100_feats_3_resolution.json",
+     "results/gaussian_varyNumModules_100_feats_4_resolution.json"],
+    "convergence100_gaussian_varyResolution_varyNumModules.pdf",
+    xlim=(2.5, 167.5))
+
+  # varyModuleSize_varyResolution(
+  #   [],
+  #   "recognition_time_varyModuleSize.pdf",
+  #   xlim=(-6.0, 400.0)
+  # )
+
+  varyModuleSize_varyNumModules(
+    ["results/varyModuleSize_100_feats_1_enlarge.json",
+     "results/varyModuleSize_100_feats_2_enlarge.json",
+     "results/varyModuleSize_100_feats_3_enlarge.json"],
+    "convergence100_gaussian_varyModuleSize_varyNumModules.pdf",
+    xlim=(0, 577.0)
+  )

--- a/projects/union_path_integration/runGaussian_varyModuleSize_varyNumModules.sh
+++ b/projects/union_path_integration/runGaussian_varyModuleSize_varyNumModules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -x
+
+cd "$(dirname "$0")"
+pwd
+
+repetitions=1
+
+python gaussian_simulation.py --numObjects 10 30 50 70 90 110 130 150 170 --numUniqueFeatures 100 --inverseReadoutResolution 3 --numModules 6 12 18 --enlargeModuleFactor 1.0 --resultName results/varyModuleSize_100_feats_1_enlarge.json --repeat $repetitions --appendResults
+
+python gaussian_simulation.py --numObjects 10 30 50 70 90 110 130 150 170 190 210 230 250 270 290 310 330 350 --numUniqueFeatures 100 --inverseReadoutResolution 3 --numModules 6 12 18 --enlargeModuleFactor 2.0 --resultName results/varyModuleSize_100_feats_2_enlarge.json --repeat $repetitions --appendResults
+
+python gaussian_simulation.py --numObjects 50 100 150 200 250 300 350 400 450 500 550 600 --numUniqueFeatures 100 --inverseReadoutResolution 3 --numModules 6 12 18 --enlargeModuleFactor 3.0 --resultName results/varyModuleSize_100_feats_3_enlarge.json --repeat $repetitions --appendResults

--- a/projects/union_path_integration/runGaussian_varyResolution_varyNumModules.sh
+++ b/projects/union_path_integration/runGaussian_varyResolution_varyNumModules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -x
+
+cd "$(dirname "$0")"
+pwd
+
+repetitions=1
+
+python gaussian_simulation.py --numObjects 10 20 30 40 50 60 70 80 90 100 110 --numUniqueFeatures 100 --inverseReadoutResolution 2 --numModules 6 12 18 --resultName results/gaussian_varyNumModules_100_feats_2_resolution.json --repeat $repetitions --appendResults
+
+python gaussian_simulation.py --numObjects 10 20 30 40 50 60 70 80 90 100 110 120 130 --numUniqueFeatures 100 --inverseReadoutResolution 3 --numModules 6 12 18 --resultName results/gaussian_varyNumModules_100_feats_3_resolution.json --repeat $repetitions --appendResults
+
+python gaussian_simulation.py --numObjects 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 --numUniqueFeatures 100 --inverseReadoutResolution 4 --numModules 6 12 18 --resultName results/gaussian_varyNumModules_100_feats_4_resolution.json --repeat $repetitions --appendResults


### PR DESCRIPTION
Here's what distinguishes this model from the other:
- It separately models the "bump size" and the "readout resolution" rather than using the 1/cellsPerModuleAxis for both.
- It models how a union of bumps is harder to readout than a single bump. (In this approach, more cells become "active" than just the union of the active cells)
- Hexagonal grids. The firing fields of a cell are arranged in a hexagon rather than in a square.
- Each firing field is round instead of square.

Other changes:

- Fix a bug: PIUNExperiment.representationSet wasn't being properly filled, so we weren't correctly detecting temporary convergences on a wrong object.
- Stop seeding the object generator with the number of objects. It should generate different objects on different runs.
- Add couple other capabilities to convergence simulation.
- Tweak the Superficial2DLocationModule so that it shares a more common interface with the new ThresholdedGaussian2DLocationModule.