### PR TITLE
PUB-867: Location network framework

### DIFF
--- a/htmresearch/frameworks/location/location_network_creation.py
+++ b/htmresearch/frameworks/location/location_network_creation.py
@@ -1,0 +1,268 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+"""
+The methods here contain factories to create networks of multiple layers for
+experimenting with grid cell location layer (L6a)
+"""
+import copy
+import json
+
+from htmresearch.frameworks.location.path_integration_union_narrowing import (
+  computeRatModuleParametersFromReadoutResolution,
+  computeRatModuleParametersFromCellCount)
+
+
+
+def createL4L6aLocationColumn(network, config, suffix=""):
+  """
+  Create a single column network containing L4 and L6a layers. L4 layer
+  processes sensor inputs while L6a processes motor commands using grid cell
+  modules. Sensory input is represented by the feature's active columns and
+  motor input is represented by the displacement vector [dx, dy].
+
+  The grid cell modules used by this network are based on
+  :class:`ThresholdedGaussian2DLocationModule` where the firing rate is computed
+  from on one or more Gaussian activity bumps. The cells are distributed
+  uniformly through the rhombus, packed in the optimal hexagonal arrangement.
+  ::
+
+                                  +-------+
+                      +---------->|       |<------------+
+                      |     +---->|  L4   |--winner---+ |
+                      |     |     |       |           | |
+                      |     |     +-------+           | |
+                      |     |       |   ^             | |
+                      |     |       |   |             | |
+                      |     |       |   |             | |
+                      |     |       v   |             | |
+                      |     |     +-------+           | |
+                      |     |     |       |           | |
+                      |     +---->|  L6a  |<----------+ |
+                      |     |     |       |--learnable--+
+                      |     |     +-------+
+                      |     |         ^
+                 feature  reset       |
+                      |     |         |
+                      |     |         |
+                   [sensorInput] [motorInput]
+
+
+  .. note::
+    Region names are "motorInput", "sensorInput", "L4", and "L6a".
+    Each name has an optional string suffix appended to it.
+
+  :param network: network to add the column
+  :type network: Network
+  :param config: Configuration parameters:
+                {
+                  "sensorInputSize": int,
+                  "inverseReadoutResolution": int or float (optional)
+                  "L4Params": {
+                    constructor parameters for :class:`ApicalTMPairRegion`
+                  },
+                  "L6aParams": {
+                    constructor parameters for :class:`Guassian2DLocationRegion`
+                  }
+                }
+
+  :type config: dict
+  :param suffix: optional string suffix appended to region name. Useful when
+                 creating multicolumn networks.
+  :type suffix: str
+
+  :return: Reference to the given network
+  :rtype: Network
+  """
+  L6aConfig = copy.deepcopy(config["L6aParams"])
+  if "inverseReadoutResolution" in config:
+    # Configure L6a based on 'resolution'
+    resolution = config.pop("inverseReadoutResolution")
+    params = computeRatModuleParametersFromReadoutResolution(resolution)
+    L6aConfig.update(params)
+  else:
+    baselineCellsPerAxis = L6aConfig.get("baselineCellsPerAxis", 6)
+    params = computeRatModuleParametersFromCellCount(L6aConfig["cellsPerAxis"],
+                                                     baselineCellsPerAxis)
+    L6aConfig.update(params)
+
+  # Configure L4 'basalInputSize' to be compatible L6a output
+  moduleCount = L6aConfig["moduleCount"]
+  cellsPerAxis = L6aConfig["cellsPerAxis"]
+  L4Config = copy.deepcopy(config["L4Params"])
+  L4Config["basalInputWidth"] = moduleCount * cellsPerAxis * cellsPerAxis
+
+  # Add regions to network
+  motorInputName = "motorInput" + suffix
+  sensorInputName = "sensorInput" + suffix
+  L4Name = "L4" + suffix
+  L6aName = "L6a" + suffix
+
+  network.addRegion(sensorInputName, "py.RawSensor",
+                    json.dumps({"outputWidth": config["sensorInputSize"]}))
+  network.addRegion(motorInputName, "py.RawValues",
+                    json.dumps({"outputWidth": 2}))
+  network.addRegion(L4Name, "py.ApicalTMPairRegion", json.dumps(L4Config))
+  network.addRegion(L6aName, "py.Guassian2DLocationRegion",
+                    json.dumps(L6aConfig))
+
+  # Link sensory input to L4
+  network.link(sensorInputName, L4Name, "UniformLink", "",
+               srcOutput="dataOut", destInput="activeColumns")
+
+  # Link motor input to L6a
+  network.link(motorInputName, L6aName, "UniformLink", "",
+               srcOutput="dataOut", destInput="displacement")
+
+  # Link L6a to L4
+  network.link(L6aName, L4Name, "UniformLink", "",
+               srcOutput="activeCells", destInput="basalInput")
+  network.link(L6aName, L4Name, "UniformLink", "",
+               srcOutput="learnableCells", destInput="basalGrowthCandidates")
+
+  # Link L4 feedback to L6a
+  network.link(L4Name, L6aName, "UniformLink", "",
+               srcOutput="activeCells", destInput="anchorInput",
+               propagationDelay=1)
+  network.link(L4Name, L6aName, "UniformLink", "",
+               srcOutput="winnerCells", destInput="anchorGrowthCandidates",
+               propagationDelay=1)
+
+  # Link reset signal to L4 and L6a
+  network.link(sensorInputName, L4Name, "UniformLink", "",
+               srcOutput="resetOut", destInput="resetIn")
+  network.link(sensorInputName, L6aName, "UniformLink", "",
+               srcOutput="resetOut", destInput="resetIn")
+
+  # Set phases appropriately
+  network.setPhases(sensorInputName, [0])
+  network.setPhases(motorInputName, [0])
+  network.setPhases(L4Name, [1])
+  network.setPhases(L6aName, [1])
+
+  return network
+
+
+
+def createL246aLocationColumn(network, config, suffix=""):
+  """
+  Create a single column network composed of L2, L4 and L6a layers.
+  L2 layer computes the object representation using :class:`ColumnPoolerRegion`,
+  L4 layer processes sensors input while L6a processes motor commands using grid
+  cell modules. Sensory input is represented by the feature's active columns and
+  motor input is represented by the displacement vector [dx, dy].
+
+  The grid cell modules used by this network are based on
+  :class:`ThresholdedGaussian2DLocationModule` where the firing rate is computed
+  from on one or more Gaussian activity bumps. The cells are distributed
+  uniformly through the rhombus, packed in the optimal hexagonal arrangement.
+  ::
+
+                               +-------+
+                        reset  |       |
+                        +----->|  L2   |<------------------+
+                        |      |       |                   |
+                        |      +-------+                   |
+                        |        |   ^                     |
+                        |        |   |                     |
+                        |        |   |                     |
+                        |        v   |                     |
+                        |      +-------+                   |
+                  +----------->|       |--predictedActive--+
+                  |     |      |  L4   |<------------+
+                  |     +----->|       |--winner---+ |
+                  |     |      +-------+           | |
+                  |     |        |   ^             | |
+                  |     |        |   |             | |
+                  |     |        |   |             | |
+                  |     |        v   |             | |
+                  |     |      +-------+           | |
+                  |     |      |       |           | |
+                  |     +----->|  L6a  |<----------+ |
+                  |     |      |       |--learnable--+
+                  |     |      +-------+
+             feature  reset        ^
+                  |     |          |
+                  |     |          |
+               [sensorInput]  [motorInput]
+
+
+  .. note::
+    Region names are "motorInput", "sensorInput". "L2", "L4", and "L6a".
+    Each name has an optional string suffix appended to it.
+
+  :param network: network to add the column
+  :type network: Network
+  :param config: Configuration parameters:
+                {
+                  "sensorInputSize": int,
+                  "enableFeedback": True,
+                  "inverseReadoutResolution": int or float (optional)
+                  "L2Params": {
+                    constructor parameters for :class:`ColumnPoolerRegion`
+                  },
+                  "L4Params": {
+                    constructor parameters for :class:`ApicalTMPairRegion`
+                  },
+                  "L6aParams": {
+                    constructor parameters for :class:`Guassian2DLocationRegion`
+                  }
+                }
+
+  :type config: dict
+  :param suffix: optional string suffix appended to region name. Useful when
+                 creating multicolumn networks.
+  :type suffix: str
+
+  :return: Reference to the given network
+  :rtype: Network
+  """
+
+  # Add L4 - L6a location layers
+  network = createL4L6aLocationColumn(network, config, suffix)
+  L4Name = "L4" + suffix
+  sensorInputName = "sensorInput" + suffix
+
+  # Add L2 - L4 object layers
+  L2Name = "L2" + suffix
+  L2Params = copy.deepcopy(config["L2Params"])
+  network.addRegion(L2Name, "py.ColumnPoolerRegion", json.dumps(L2Params))
+
+  # Link L4 to L2
+  network.link(L4Name, L2Name, "UniformLink", "",
+               srcOutput="activeCells", destInput="feedforwardInput")
+  network.link(L4Name, L2Name, "UniformLink", "",
+               srcOutput="predictedActiveCells",
+               destInput="feedforwardGrowthCandidates")
+
+  # Link L2 feedback to L4
+  if config.get("enableFeedback", True):
+    network.link(L2Name, L4Name, "UniformLink", "",
+                 srcOutput="feedForwardOutput", destInput="apicalInput",
+                 propagationDelay=1)
+
+  # Link reset output to L2
+  network.link(sensorInputName, L2Name, "UniformLink", "",
+               srcOutput="resetOut", destInput="resetIn")
+
+  # Set L2 phase to be after L4
+  network.setPhases(L2Name, [3])
+
+  return network

--- a/htmresearch/regions/ApicalTMPairRegion.py
+++ b/htmresearch/regions/ApicalTMPairRegion.py
@@ -248,9 +248,10 @@ class ApicalTMPairRegion(PyRegion):
           "defaultValue": "false"
         },
         "maxSynapsesPerSegment": {
-          "description": "The maximum number of synapses per segment",
+          "description": "The maximum number of synapses per segment. Use -1 "
+                         "for unlimited.",
           "accessMode": "Read",
-          "dataType": "UInt32",
+          "dataType": "Int32",
           "count": 1
         },
         "maxSegmentsPerCell": {

--- a/htmresearch/regions/Guassian2DLocationRegion.py
+++ b/htmresearch/regions/Guassian2DLocationRegion.py
@@ -257,7 +257,7 @@ class Guassian2DLocationRegion(PyRegion):
           defaultValue="probabilistic",
           count=0,
         ),
-        learn=dict(
+        learningMode=dict(
           description="A boolean flag that indicates whether or not we should "
                       "learn by associating the location with the sensory "
                       "input",
@@ -299,7 +299,7 @@ class Guassian2DLocationRegion(PyRegion):
                permanenceDecrement=0.0,
                maxSynapsesPerSegment=-1,
                bumpOverlapMethod="probabilistic",
-               learn=False,
+               learningMode=False,
                seed=42,
                **kwargs):
     if moduleCount <= 0 or cellsPerAxis <= 0:
@@ -324,7 +324,7 @@ class Guassian2DLocationRegion(PyRegion):
     self.permanenceDecrement = permanenceDecrement
     self.maxSynapsesPerSegment = maxSynapsesPerSegment
     self.bumpOverlapMethod = bumpOverlapMethod
-    self.learn = learn
+    self.learningMode = learningMode
     self.seed = seed
 
     self._modules = None
@@ -397,7 +397,7 @@ class Guassian2DLocationRegion(PyRegion):
 
       # Compute sensation
       if anchorInput is not None or anchorGrowthCandidates is not None:
-        module.sensoryCompute(anchorInput, anchorGrowthCandidates, self.learn)
+        module.sensoryCompute(anchorInput, anchorGrowthCandidates, self.learningMode)
 
       # Concatenate outputs
       start = i * self.cellCount

--- a/htmresearch/regions/Guassian2DLocationRegion.py
+++ b/htmresearch/regions/Guassian2DLocationRegion.py
@@ -338,22 +338,22 @@ class Guassian2DLocationRegion(PyRegion):
       self._modules = []
       for i in xrange(self.moduleCount):
         self._modules.append(ThresholdedGaussian2DLocationModule(
-          self.cellsPerAxis,
-          self.scale[i],
-          self.orientation[i],
-          self.anchorInputSize,
-          self.activeFiringRate,
-          self.bumpSigma,
-          self.activationThreshold,
-          self.initialPermanence,
-          self.connectedPermanence,
-          self.learningThreshold,
-          self.sampleSize,
-          self.permanenceIncrement,
-          self.permanenceDecrement,
-          self.maxSynapsesPerSegment,
-          self.bumpOverlapMethod,
-          self.seed))
+          cellsPerAxis=self.cellsPerAxis,
+          scale=self.scale[i],
+          orientation=self.orientation[i],
+          anchorInputSize=self.anchorInputSize,
+          activeFiringRate=self.activeFiringRate,
+          bumpSigma=self.bumpSigma,
+          activationThreshold=self.activationThreshold,
+          initialPermanence=self.initialPermanence,
+          connectedPermanence=self.connectedPermanence,
+          learningThreshold=self.learningThreshold,
+          sampleSize=self.sampleSize,
+          permanenceIncrement=self.permanenceIncrement,
+          permanenceDecrement=self.permanenceDecrement,
+          maxSynapsesPerSegment=self.maxSynapsesPerSegment,
+          bumpOverlapMethod=self.bumpOverlapMethod,
+          seed=self.seed))
 
   def compute(self, inputs, outputs):
     """
@@ -383,7 +383,6 @@ class Guassian2DLocationRegion(PyRegion):
     anchorGrowthCandidates = inputs.get("anchorGrowthCandidates")
     if anchorGrowthCandidates is not None:
       anchorGrowthCandidates = anchorGrowthCandidates.nonzero()[0]
-
 
     # Concatenate the output of all modules
     outputs["activeCells"][:] = 0

--- a/htmresearch/regions/Guassian2DLocationRegion.py
+++ b/htmresearch/regions/Guassian2DLocationRegion.py
@@ -424,7 +424,7 @@ class Guassian2DLocationRegion(PyRegion):
     Set the value of a Spec parameter.
     """
     spec = self.getSpec()
-    if 'learn' not in spec['parameters']:
+    if parameterName not in spec['parameters']:
       raise Exception("Unknown parameter: " + parameterName)
 
     setattr(self, parameterName, parameterValue)

--- a/htmresearch/regions/Guassian2DLocationRegion.py
+++ b/htmresearch/regions/Guassian2DLocationRegion.py
@@ -1,0 +1,445 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+from nupic.bindings.regions.PyRegion import PyRegion
+
+from htmresearch.algorithms.location_modules import (
+  ThresholdedGaussian2DLocationModule)
+
+
+
+class Guassian2DLocationRegion(PyRegion):
+  """
+  The Guassian2DLocationRegion computes the location of the sensor in the space
+  of the object given sensory and motor inputs using gaussian grid cell modules
+  to update the location.
+
+  Sensory input drives the activity of the region while Motor input causes the
+  region to perform path integration, updating its activity.
+
+  The grid cell module algorithm used by this region is based on the
+  :class:`ThresholdedGaussian2DLocationModule` where each module has one or more
+  gaussian activity bumps that move as the population receives motor input. When
+  two bumps are near each other, the intermediate cells have higher firing rates
+  than they would with a single bump. The cells with firing rates above a
+  certain threshold are considered "active". When the network receives a motor
+  command, it shifts its bumps.
+
+  The cells are distributed uniformly through the rhombus, packed in the optimal
+  hexagonal arrangement. During learning, the cell nearest to the current phase
+  is associated with the sensed feature.
+
+  See :class:`ThresholdedGaussian2DLocationModule` for more details
+  """
+
+  @classmethod
+  def getSpec(cls):
+    """
+    Return the spec for the Guassian2DLocationRegion
+    """
+    spec = dict(
+      description=Guassian2DLocationRegion.__doc__,
+      singleNodeOnly=True,
+      inputs=dict(
+        anchorInput=dict(
+          description="An array of 0's and 1's representing the sensory input "
+                      "during inference. This will often come from a "
+                      "feature-location pair layer (L4 active cells).",
+          dataType="Real32",
+          count=0,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False,
+        ),
+        anchorGrowthCandidates=dict(
+          description="An array of 0's and 1's representing the sensory input "
+                      "during learning. This will often come from a "
+                      "feature-location pair layer (L4 winner cells).",
+          dataType="Real32",
+          count=0,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False,
+        ),
+        displacement=dict(
+          description="Pair of floats representing the displacement as 2D "
+                      "translation vector [dx, dy].",
+          dataType="Real32",
+          count=2,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False,
+        ),
+        resetIn=dict(
+          description="Clear all cell activity.",
+          dataType="Real32",
+          count=1,
+          required=False,
+          regionLevel=True,
+          isDefaultInput=False,
+          requireSplitterMap=False,
+        )
+      ),
+      outputs=dict(
+        activeCells=dict(
+          description="A binary output containing a 1 for every"
+                      " cell that is currently active.",
+          dataType="Real32",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=False
+        ),
+        learnableCells=dict(
+          description="A binary output containing a 1 for every"
+                      " cell that is currently learnable",
+          dataType="Real32",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=False
+        ),
+        sensoryAssociatedCells=dict(
+          description="A binary output containing a 1 for every"
+                      " cell that is currently associated with a sensory input",
+          dataType="Real32",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=False
+        )
+      ),
+      parameters=dict(
+        moduleCount=dict(
+          description="Number of grid cell modules",
+          dataType="UInt32",
+          accessMode="Read",
+          count=1
+        ),
+        cellsPerAxis=dict(
+          description="Determines the number of cells. Determines how space is "
+                      "divided between the cells",
+          dataType="UInt32",
+          accessMode="Read",
+          count=1
+        ),
+        scale=dict(
+          description="Determines the amount of world space covered by all of "
+                      "the cells combined. In grid cell terminology, this is "
+                      "equivalent to the 'scale' of a module. One scale value "
+                      "for each grid cell module. Array size must match "
+                      "'moduleCount' parameter",
+          dataType="Real32",
+          accessMode="Read",
+          count=0,
+        ),
+        orientation=dict(
+          description="The rotation of this map, measured in radians. One "
+                      "orientation value for each grid cell module. Array size "
+                      "must match 'moduleCount' parameter",
+          dataType="Real32",
+          accessMode="Read",
+          count=0,
+        ),
+        anchorInputSize=dict(
+          description="The number of input bits in the anchor input",
+          dataType="UInt32",
+          accessMode="Read",
+          count=1,
+        ),
+        activeFiringRate=dict(
+          description="Between 0.0 and 1.0. A cell is considered active if its "
+                      "firing rate is at least this value",
+          dataType="Real32",
+          accessMode="Read",
+          count=1,
+        ),
+        bumpSigma=dict(
+          description="Specifies the diameter of a gaussian bump, in units of "
+                      "'rhombus edges'. A single edge of the rhombus has length "
+                      "1, and this bumpSigma would typically be less than 1. We "
+                      "often use 0.18172 as an estimate for the sigma of a rat "
+                      "entorhinal bump",
+          dataType="Real32",
+          accessMode="Read",
+          count=1,
+          defaultValue=0.18172,
+        ),
+        activationThreshold=dict(
+          description="If the number of active connected synapses on a "
+                      "segment is at least this threshold, the segment "
+                      "is said to be active",
+          accessMode="Read",
+          dataType="UInt32",
+          count=1,
+          constraints="",
+          defaultValue=10
+        ),
+        initialPermanence=dict(
+          description="Initial permanence of a new synapse",
+          accessMode="Read",
+          dataType="Real32",
+          count=1,
+          constraints="",
+          defaultValue=0.21
+        ),
+        connectedPermanence=dict(
+          description="If the permanence value for a synapse is greater "
+                      "than this value, it is said to be connected",
+          accessMode="Read",
+          dataType="Real32",
+          count=1,
+          constraints="",
+          defaultValue=0.50
+        ),
+        learningThreshold=dict(
+          description="Minimum overlap required for a segment to learned",
+          accessMode="Read",
+          dataType="UInt32",
+          count=1,
+          defaultValue=10
+        ),
+        sampleSize=dict(
+          description="The desired number of active synapses for an "
+                      "active cell",
+          accessMode="Read",
+          dataType="UInt32",
+          count=1,
+          defaultValue=20
+        ),
+        permanenceIncrement=dict(
+          description="Amount by which permanences of synapses are "
+                      "incremented during learning",
+          accessMode="Read",
+          dataType="Real32",
+          count=1,
+          defaultValue=0.1
+        ),
+        permanenceDecrement=dict(
+          description="Amount by which permanences of synapses are "
+                      "decremented during learning",
+          accessMode="Read",
+          dataType="Real32",
+          count=1,
+          defaultValue=0.0
+        ),
+        maxSynapsesPerSegment=dict(
+          description="The maximum number of synapses per segment",
+          accessMode="Read",
+          dataType="UInt32",
+          count=1,
+          defaultValue=-1
+        ),
+        bumpOverlapMethod=dict(
+          description="Specifies the firing rate of a cell when it's part of "
+                      "two bumps. ('probabilistic' or 'sum')",
+          dataType="Byte",
+          accessMode="Read",
+          constraints=("enum: probabilistic, sum"),
+          defaultValue="probabilistic",
+          count=0,
+        ),
+        learn=dict(
+          description="A boolean flag that indicates whether or not we should "
+                      "learn by associating the location with the sensory "
+                      "input",
+          dataType="Bool",
+          accessMode="ReadWrite",
+          count=1,
+          defaultValue=False
+        ),
+        seed=dict(
+          description="Seed for the random number generator",
+          accessMode="Read",
+          dataType="UInt32",
+          count=1,
+          defaultValue=42
+        )
+      ),
+      commands=dict(
+        reset=dict(description="Clear all cell activity"),
+        activateRandomLocation=dict(description="Set the location to a random "
+                                                "point"),
+      )
+    )
+    return spec
+
+  def __init__(self,
+               moduleCount,
+               cellsPerAxis,
+               scale,
+               orientation,
+               anchorInputSize,
+               activeFiringRate,
+               bumpSigma,
+               activationThreshold=10,
+               initialPermanence=0.21,
+               connectedPermanence=0.50,
+               learningThreshold=10,
+               sampleSize=20,
+               permanenceIncrement=0.1,
+               permanenceDecrement=0.0,
+               maxSynapsesPerSegment=-1,
+               bumpOverlapMethod="probabilistic",
+               learn=False,
+               seed=42,
+               **kwargs):
+    if moduleCount <= 0 or cellsPerAxis <= 0:
+      raise TypeError("Parameters moduleCount and cellsPerAxis must be > 0")
+    if moduleCount != len(scale) or moduleCount != len(orientation):
+      raise TypeError("scale and orientation arrays len must match moduleCount")
+
+    self.moduleCount = moduleCount
+    self.cellsPerAxis = cellsPerAxis
+    self.cellCount = cellsPerAxis * cellsPerAxis
+    self.scale = list(scale)
+    self.orientation = list(orientation)
+    self.anchorInputSize = anchorInputSize
+    self.activeFiringRate = activeFiringRate
+    self.bumpSigma = bumpSigma
+    self.activationThreshold = activationThreshold
+    self.initialPermanence = initialPermanence
+    self.connectedPermanence = connectedPermanence
+    self.learningThreshold = learningThreshold
+    self.sampleSize = sampleSize
+    self.permanenceIncrement = permanenceIncrement
+    self.permanenceDecrement = permanenceDecrement
+    self.maxSynapsesPerSegment = maxSynapsesPerSegment
+    self.bumpOverlapMethod = bumpOverlapMethod
+    self.learn = learn
+    self.seed = seed
+
+    self._modules = None
+
+    PyRegion.__init__(self, **kwargs)
+
+  def initialize(self):
+    """ Initialize grid cell modules """
+
+    if self._modules is None:
+      self._modules = []
+      for i in xrange(self.moduleCount):
+        self._modules.append(ThresholdedGaussian2DLocationModule(
+          self.cellsPerAxis,
+          self.scale[i],
+          self.orientation[i],
+          self.anchorInputSize,
+          self.activeFiringRate,
+          self.bumpSigma,
+          self.activationThreshold,
+          self.initialPermanence,
+          self.connectedPermanence,
+          self.learningThreshold,
+          self.sampleSize,
+          self.permanenceIncrement,
+          self.permanenceDecrement,
+          self.maxSynapsesPerSegment,
+          self.bumpOverlapMethod,
+          self.seed))
+
+  def compute(self, inputs, outputs):
+    """
+    Compute the location based on the 'displacement' and 'anchorInput' by first
+    applying the  movement, if 'displacement' is present in the 'input' array
+    and then applying the sensation if 'anchorInput' is present in the input
+    array. The 'anchorGrowthCandidates' input array is used during learning
+
+    See :meth:`ThresholdedGaussian2DLocationModule.movementCompute` and
+        :meth:`ThresholdedGaussian2DLocationModule.sensoryCompute`
+    """
+
+    if "resetIn" in inputs:
+      if len(inputs['resetIn']) != 1:
+        raise Exception("resetIn has invalid length")
+      self.reset()
+      outputs["activeCells"][:] = 0
+      outputs["learnableCells"][:] = 0
+      outputs["sensoryAssociatedCells"][:] = 0
+      return
+
+    displacement = inputs.get("displacement")
+    anchorInput = inputs.get("anchorInput")
+    if anchorInput is not None:
+      anchorInput = anchorInput.nonzero()[0]
+
+    anchorGrowthCandidates = inputs.get("anchorGrowthCandidates")
+    if anchorGrowthCandidates is not None:
+      anchorGrowthCandidates = anchorGrowthCandidates.nonzero()[0]
+
+
+    # Concatenate the output of all modules
+    outputs["activeCells"][:] = 0
+    outputs["learnableCells"][:] = 0
+    outputs["sensoryAssociatedCells"][:] = 0
+    for i in xrange(self.moduleCount):
+      module = self._modules[i]
+
+      # Compute movement
+      if displacement is not None:
+        module.movementCompute(displacement)
+
+      # Compute sensation
+      if anchorInput is not None or anchorGrowthCandidates is not None:
+        module.sensoryCompute(anchorInput, anchorGrowthCandidates, self.learn)
+
+      # Concatenate outputs
+      start = i * self.cellCount
+      end = start + self.cellCount
+      outputs["activeCells"][start:end][module.getActiveCells()] = 1
+      outputs["learnableCells"][start:end][module.getLearnableCells()] = 1
+      outputs["sensoryAssociatedCells"][start:end][module.getSensoryAssociatedCells()] = 1
+
+  def reset(self):
+    """ Clear the active cells """
+    for module in self._modules:
+      module.reset()
+
+  def activateRandomLocation(self):
+    """
+    Set the location to a random point.
+    """
+    for module in self._modules:
+      module.activateRandomLocation()
+
+  def setParameter(self, parameterName, index, parameterValue):
+    """
+    Set the value of a Spec parameter.
+    """
+    spec = self.getSpec()
+    if 'learn' not in spec['parameters']:
+      raise Exception("Unknown parameter: " + parameterName)
+
+    setattr(self, parameterName, parameterValue)
+
+  def getOutputElementCount(self, name):
+    """
+    Returns the size of the output array
+    """
+    if name in ["activeCells", "learnableCells", "sensoryAssociatedCells"]:
+      return self.cellCount * self.moduleCount
+    else:
+      raise Exception("Invalid output name specified: " + name)
+
+  def getModules(self):
+    """
+    Returns underlying list of modules used by this region
+    """
+    return self._modules

--- a/htmresearch/regions/RawValues.py
+++ b/htmresearch/regions/RawValues.py
@@ -1,0 +1,118 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+from collections import deque
+
+from nupic.bindings.regions.PyRegion import PyRegion
+
+
+
+class RawValues(PyRegion):
+  """
+  RawDate is a simple region used to send raw scalar values into networks.
+
+  It accepts data using the command "addDataToQueue" or through the function
+  addDataToQueue() which can be called directly from Python. Data is queued up
+  in a FIFO and each call to compute pops the top element.
+
+  Each data record consists of list of floats and a 0/1 reset flag.
+  """
+
+  def __init__(self, outputWidth=1):
+    self.outputWidth = outputWidth
+    self.queue = deque()
+
+  @classmethod
+  def getSpec(cls):
+    spec = dict(
+      description=RawValues.__doc__,
+      singleNodeOnly=True,
+      outputs=dict(
+        dataOut=dict(
+          description="List of floats",
+          dataType="Real32",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=True
+        ),
+        resetOut=dict(
+          description="Reset flag",
+          dataType="Bool",
+          count=1,
+          regionLevel=True,
+          isDefaultOutput=False
+        ),
+      ),
+      inputs=dict(),
+      parameters=dict(
+        outputWidth=dict(
+          description="Size of output data",
+          dataType="UInt32",
+          accessMode="ReadWrite",
+          count=1,
+          defaultValue=1,
+        )
+      ),
+      commands=dict(
+        addDataToQueue=dict(description="Add data to region. Each data record "
+                                        "consists of list of and a reset flag")
+      )
+    )
+    return spec
+
+  def compute(self, inputs, outputs):
+    """
+    Get the next record from the queue and outputs it.
+    """
+    if len(self.queue) > 0:
+      # Take the top element of the data queue
+      data = self.queue.pop()
+      # Copy data into output vectors
+      outputs["resetOut"][0] = data["reset"]
+      outputs["dataOut"][:] = data["dataOut"]
+
+  def addDataToQueue(self, displacement, reset=False):
+    """
+    Add the given displacement to the region's internal queue. Calls to compute
+    will cause items in the queue to be dequeued in FIFO order.
+
+    :param displacement: Two floats representing translation vector [dx, dy] to
+                         be passed to the linked regions via 'dataOut'
+    :type displacement: list
+    :param reset: Reset flag to be passed to the linked regions via 'resetOut'
+    :type reset: bool
+    """
+    self.queue.appendleft({
+      "dataOut": list(displacement),
+      "reset": bool(reset)
+    })
+
+  def getOutputElementCount(self, name):
+    if name == "resetOut":
+      return 1
+
+    elif name == "dataOut":
+      return self.outputWidth
+
+    else:
+      raise Exception("Unknown output {}.".format(name))
+
+  def initialize(self):
+    pass

--- a/htmresearch/support/register_regions.py
+++ b/htmresearch/support/register_regions.py
@@ -38,7 +38,8 @@ def registerAllResearchRegions():
   for regionName in ["TemporalPoolerRegion",
                      "ApicalTMPairRegion", "ApicalTMSequenceRegion",
                      "RawSensor", "ColumnPoolerRegion",
-                     "CoordinateSensorRegion"]:
+                     "CoordinateSensorRegion", "Guassian2DLocationRegion",
+                     "RawValues"]:
     registerResearchRegion(regionName)
 
 

--- a/tests/frameworks/location/location_network_creation_test.py
+++ b/tests/frameworks/location/location_network_creation_test.py
@@ -1,0 +1,219 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+"""
+  Test L4-L6a location network factory
+"""
+import math
+import random
+import unittest
+from collections import defaultdict
+
+import numpy as np
+from nupic.engine import Network
+
+from htmresearch.frameworks.location.location_network_creation import (
+  createL4L6aLocationColumn)
+from htmresearch.support.register_regions import registerAllResearchRegions
+
+NUM_OF_COLUMNS = 150
+CELLS_PER_COLUMN = 16
+NUM_OF_CELLS = NUM_OF_COLUMNS * CELLS_PER_COLUMN
+
+# Feature encoded into active columns. It could be also interpreted as the
+# output of the spatial pooler
+FEATURE_ACTIVE_COLUMNS = {
+  "A": np.random.choice(NUM_OF_COLUMNS, NUM_OF_COLUMNS / 10).tolist(),
+  "B": np.random.choice(NUM_OF_COLUMNS, NUM_OF_COLUMNS / 10).tolist(),
+}
+
+OBJECTS = [
+  {"name": "Object 1",
+   "features": [{"top": 0, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 0, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "A"}
+                ]},
+  {"name": "Object 2",
+   "features": [{"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "A"}
+                ]},
+  {"name": "Object 3",
+   "features": [{"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 20, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 20, "left": 20, "width": 10, "height": 10, "name": "B"}
+                ]},
+  {"name": "Object 4",
+   "features": [{"top": 0, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 20, "width": 10, "height": 10, "name": "B"}
+                ]}]
+
+
+
+class LocationNetworkFactoryTest(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    registerAllResearchRegions()
+
+  def _setLearning(self, network, learn):
+    for region in network.regions.values():
+      if region.type == "py.ColumnPoolerRegion":
+        region.setParameter("learningMode", learn)
+      elif region.type == "py.ApicalTMPairRegion":
+        region.setParameter("learn", learn)
+      elif region.type == "py.Guassian2DLocationRegion":
+        region.setParameter("learn", learn)
+
+
+
+  def testCreateL4L6aLocationColumn(self):
+    """
+    Test 'createL4L6aLocationColumn' by inferring a set of hand crafted objects
+    """
+    scale = []
+    orientation = []
+    # Initialize L6a location region with 5 modules varying scale by sqrt(2) and
+    # 4 different random orientations for each scale
+    for i in xrange(5):
+      for _ in xrange(4):
+        angle = np.radians(random.gauss(7.5, 7.5))
+        orientation.append(random.choice([angle, -angle]))
+        scale.append(10.0 * (math.sqrt(2) ** i))
+
+    net = Network()
+    createL4L6aLocationColumn(net, {
+      "inverseReadoutResolution": 8,
+      "sensorInputSize": NUM_OF_CELLS,
+      "L4Params": {
+        "columnCount": NUM_OF_COLUMNS,
+        "cellsPerColumn": CELLS_PER_COLUMN,
+        "activationThreshold": 15,
+        "minThreshold": 15,
+        "initialPermanence": 1.0,
+        "implementation": "ApicalTiebreak",
+        "maxSynapsesPerSegment": -1
+      },
+      "L6aParams": {
+        "moduleCount": len(scale),
+        "scale": scale,
+        "orientation": orientation,
+        "anchorInputSize": NUM_OF_CELLS,
+        "activationThreshold": 8,
+        "initialPermanence": 1.0,
+        "connectedPermanence": 0.5,
+        "learningThreshold": 8,
+        "sampleSize": 10,
+        "permanenceIncrement": 0.1,
+        "permanenceDecrement": 0.0,
+        "bumpOverlapMethod": "probabilistic"
+      }
+    })
+    net.initialize()
+
+    L4 = net.regions['L4']
+    L6a = net.regions['L6a']
+    sensor = net.regions['sensorInput'].getSelf()
+    motor = net.regions['motorInput'].getSelf()
+
+    # Keeps a list of learned objects
+    learnedRepresentations = defaultdict(list)
+
+    # Learn Objects
+    self._setLearning(net, True)
+
+    for objectDescription in OBJECTS:
+      reset = True
+      previousLocation = None
+      L6a.executeCommand(["activateRandomLocation"])
+
+      for iFeature, feature in enumerate(objectDescription["features"]):
+        # Move the sensor to the center of the object
+        locationOnObject = np.array([feature["top"] + feature["height"] / 2.,
+                                     feature["left"] + feature["width"] / 2.])
+
+        # Calculate displacement from previous location
+        if previousLocation is not None:
+          motor.addDataToQueue(locationOnObject - previousLocation)
+        previousLocation = locationOnObject
+
+        # Sense feature at location
+        sensor.addDataToQueue(FEATURE_ACTIVE_COLUMNS[feature["name"]], reset, 0)
+        net.run(1)
+        reset = False
+
+        # Save learned representations
+        representation = L6a.getOutputData("sensoryAssociatedCells")
+        representation = representation.nonzero()[0]
+        learnedRepresentations[
+          (objectDescription["name"], iFeature)] = representation
+
+    # Infer objects
+    self._setLearning(net, False)
+
+    for objectDescription in OBJECTS:
+      reset = True
+      previousLocation = None
+      inferred = False
+
+      features = objectDescription["features"]
+      touchSequence = range(len(features))
+      random.shuffle(touchSequence)
+
+      for iFeature in touchSequence:
+        feature = features[iFeature]
+
+        # Move the sensor to the center of the object
+        locationOnObject = np.array([feature["top"] + feature["height"] / 2.,
+                                     feature["left"] + feature["width"] / 2.])
+
+        # Calculate displacement from previous location
+        if previousLocation is not None:
+          motor.addDataToQueue(locationOnObject - previousLocation)
+        previousLocation = locationOnObject
+
+        # Sense feature at location
+        sensor.addDataToQueue(FEATURE_ACTIVE_COLUMNS[feature["name"]], reset, 0)
+        net.run(1)
+        reset = False
+
+        representation = L6a.getOutputData("sensoryAssociatedCells")
+        representation = representation.nonzero()[0]
+        target_representations = set(
+          learnedRepresentations[(objectDescription["name"], iFeature)])
+
+        inferred = (set(representation) <= target_representations)
+        if inferred:
+          break
+
+      self.assertTrue(inferred)

--- a/tests/frameworks/location/location_network_creation_test.py
+++ b/tests/frameworks/location/location_network_creation_test.py
@@ -93,7 +93,7 @@ class LocationNetworkFactoryTest(unittest.TestCase):
       elif region.type == "py.ApicalTMPairRegion":
         region.setParameter("learn", learn)
       elif region.type == "py.Guassian2DLocationRegion":
-        region.setParameter("learn", learn)
+        region.setParameter("learningMode", learn)
 
 
 

--- a/tests/regions/location_region_test.py
+++ b/tests/regions/location_region_test.py
@@ -1,0 +1,302 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+import json
+import math
+import random
+import unittest
+from collections import defaultdict
+
+import numpy as np
+from nupic.engine import Network
+
+from htmresearch.frameworks.location.path_integration_union_narrowing import (
+  computeRatModuleParametersFromReadoutResolution)
+from htmresearch.support.register_regions import registerAllResearchRegions
+
+NUM_OF_COLUMNS = 150
+CELLS_PER_COLUMN = 16
+NUM_OF_CELLS = NUM_OF_COLUMNS * CELLS_PER_COLUMN
+
+FEATURE_ACTIVE_COLUMNS = {
+  "A": np.random.choice(NUM_OF_COLUMNS, NUM_OF_COLUMNS / 10).tolist(),
+  "B": np.random.choice(NUM_OF_COLUMNS, NUM_OF_COLUMNS / 10).tolist(),
+}
+
+FEATURE_CANDIDATE_SDR = {
+  "A": np.random.choice(NUM_OF_CELLS, NUM_OF_CELLS / 10).tolist(),
+  "B": np.random.choice(NUM_OF_CELLS, NUM_OF_CELLS / 10).tolist(),
+}
+
+OBJECTS = [
+  {"name": "Object 1",
+   "features": [{"top": 0, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 0, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "A"}]},
+  {"name": "Object 2",
+   "features": [{"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "A"}]},
+  {"name": "Object 3",
+   "features": [{"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 20, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 20, "left": 20, "width": 10, "height": 10, "name": "B"}]},
+  {"name": "Object 4",
+   "features": [{"top": 0, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 10, "width": 10, "height": 10, "name": "A"},
+                {"top": 0, "left": 20, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 0, "width": 10, "height": 10, "name": "A"},
+                {"top": 10, "left": 20, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 0, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 10, "width": 10, "height": 10, "name": "B"},
+                {"top": 20, "left": 20, "width": 10, "height": 10, "name": "B"}]},
+]
+
+
+
+def _createNetwork(inverseReadoutResolution, anchorInputSize):
+  """
+  Create a simple network connecting sensor and motor inputs to the location
+  region. Use :meth:`RawSensor.addDataToQueue` to add sensor input and growth
+  candidates. Use :meth:`RawValues.addDataToQueue` to add motor input.
+  ::
+                        +----------+
+    [   sensor*   ] --> |          | --> [     activeCells        ]
+    [ candidates* ] --> | location | --> [    learnableCells      ]
+    [    motor    ] --> |          | --> [ sensoryAssociatedCells ]
+                        +----------+
+
+  :param inverseReadoutResolution:
+    Specifies the diameter of the circle of phases in the rhombus encoded by a
+    bump.
+  :type inverseReadoutResolution: int
+
+  :type anchorInputSize: int
+  :param anchorInputSize:
+    The number of input bits in the anchor input.
+
+  .. note::
+    (*) This function will only add the 'sensor' and 'candidates' regions when
+    'anchorInputSize' is greater than zero. This is useful if you would like to
+    compute locations ignoring sensor input
+
+  .. seealso::
+     - :py:func:`htmresearch.frameworks.location.path_integration_union_narrowing.createRatModuleFromReadoutResolution`
+
+  """
+  net = Network()
+
+  # Create simple region to pass motor commands as displacement vectors (dx, dy)
+  net.addRegion("motor", "py.RawValues", json.dumps({
+    "outputWidth": 2
+  }))
+
+  if anchorInputSize > 0:
+    # Create simple region to pass growth candidates
+    net.addRegion("candidates", "py.RawSensor", json.dumps({
+      "outputWidth": anchorInputSize
+    }))
+
+    # Create simple region to pass sensor input
+    net.addRegion("sensor", "py.RawSensor", json.dumps({
+      "outputWidth": anchorInputSize
+    }))
+
+  # Initialize region with 5 modules varying scale by sqrt(2) and 4 different
+  # random orientations for each scale
+  scale = []
+  orientation = []
+  for i in xrange(5):
+    for _ in xrange(4):
+      angle = np.radians(random.gauss(7.5, 7.5))
+      orientation.append(random.choice([angle, -angle]))
+      scale.append(10.0 * (math.sqrt(2) ** i))
+
+  # Create location region
+  params = computeRatModuleParametersFromReadoutResolution(inverseReadoutResolution)
+  params.update({
+    "moduleCount": len(scale),
+    "scale": scale,
+    "orientation": orientation,
+    "anchorInputSize": anchorInputSize,
+    "activationThreshold": 8,
+    "initialPermanence": 1.0,
+    "connectedPermanence": 0.5,
+    "learningThreshold": 8,
+    "sampleSize": 10,
+    "permanenceIncrement": 0.1,
+    "permanenceDecrement": 0.0,
+    "bumpOverlapMethod": "probabilistic"
+  })
+  net.addRegion("location", "py.Guassian2DLocationRegion", json.dumps(params))
+
+  if anchorInputSize > 0:
+    # Link sensor
+    net.link("sensor", "location", "UniformLink", "",
+             srcOutput="dataOut", destInput="anchorInput")
+    net.link("sensor", "location", "UniformLink", "",
+             srcOutput="resetOut", destInput="resetIn")
+    net.link("candidates", "location", "UniformLink", "",
+             srcOutput="dataOut", destInput="anchorGrowthCandidates")
+
+  # Link motor input
+  net.link("motor", "location", "UniformLink", "",
+           srcOutput="dataOut", destInput="displacement")
+
+  # Initialize network objects
+  net.initialize()
+
+  return net
+
+
+
+class Guassian2DLocationRegionTest(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    registerAllResearchRegions()
+
+  def testPathIntegration(self):
+    """
+    Test the region path integration properties by moving the sensor around
+    verifying the location representations are different when the sensor moves
+    and matches the initial representation when returning to the start location
+    """
+    # Create location only network
+    net = _createNetwork(anchorInputSize=0,
+                         inverseReadoutResolution=8)
+    location = net.regions['location']
+    motor = net.regions['motor'].getSelf()
+
+    # Start from a random location
+    location.executeCommand(["activateRandomLocation"])
+    net.run(1)
+    start = location.getOutputData("activeCells").nonzero()[0]
+
+    # Move up 10
+    motor.addDataToQueue([0, 10])
+    net.run(1)
+
+    # mid location should not match the start location
+    mid = location.getOutputData("activeCells").nonzero()[0]
+    with self.assertRaises(AssertionError):
+      np.testing.assert_array_equal(start, mid)
+
+    # Move down 10 in two steps ending at the initial location
+    motor.addDataToQueue([0, -5])
+    motor.addDataToQueue([0, -5])
+    net.run(2)
+
+    # end location should match the start location
+    end = location.getOutputData("activeCells").nonzero()[0]
+    np.testing.assert_equal(start, end)
+
+  def testLearning(self):
+    """
+    Test ability to learn objects based on their features and locations.
+    """
+    # Create network
+    net = _createNetwork(anchorInputSize=NUM_OF_CELLS,
+                         inverseReadoutResolution=8)
+    location = net.regions['location']
+    motor = net.regions['motor'].getSelf()
+    sensor = net.regions['sensor'].getSelf()
+    candidates = net.regions['candidates'].getSelf()
+
+    # Keeps a list of learned objects
+    learnedRepresentations = defaultdict(list)
+
+    # Learn Objects
+    location.setParameter("learn", True)
+
+    for objectDescription in OBJECTS:
+      reset = True
+      previousLocation = None
+      location.executeCommand(["activateRandomLocation"])
+
+      for iFeature, feature in enumerate(objectDescription["features"]):
+        featureName = feature["name"]
+
+        # Move the sensor to the center of the object
+        locationOnObject = np.array([feature["top"] + feature["height"] / 2.,
+                                     feature["left"] + feature["width"] / 2.])
+        # Calculate displacement from previous location
+        if previousLocation is not None:
+          motor.addDataToQueue(locationOnObject - previousLocation)
+        previousLocation = locationOnObject
+
+        # Sense feature at location
+        sensor.addDataToQueue(FEATURE_ACTIVE_COLUMNS[featureName], reset, 0)
+        candidates.addDataToQueue(FEATURE_CANDIDATE_SDR[featureName], reset, 0)
+        net.run(1)
+        reset = False
+
+        # Save learned representation
+        representation = location.getOutputData("sensoryAssociatedCells")
+        representation = representation.nonzero()[0]
+        learnedRepresentations[
+          (objectDescription["name"], iFeature)] = representation
+
+    # Infer learned objects
+    location.setParameter("learn", False)
+
+    for objectDescription in OBJECTS:
+      reset = True
+      previousLocation = None
+      inferred = False
+
+      features = objectDescription["features"]
+      touchSequence = range(len(features))
+      random.shuffle(touchSequence)
+
+      for iFeature in touchSequence:
+        feature = features[iFeature]
+
+        # Move the sensor to the center of the object
+        locationOnObject = np.array([feature["top"] + feature["height"] / 2.,
+                                     feature["left"] + feature["width"] / 2.])
+
+        # Calculate displacement from previous location
+        if previousLocation is not None:
+          motor.addDataToQueue(locationOnObject - previousLocation)
+        previousLocation = locationOnObject
+
+        # Sense feature at location
+        sensor.addDataToQueue(FEATURE_ACTIVE_COLUMNS[featureName], reset, 0)
+        candidates.addDataToQueue(FEATURE_CANDIDATE_SDR[featureName], reset, 0)
+        net.run(1)
+
+        representation = location.getOutputData("sensoryAssociatedCells")
+        representation = set(representation.nonzero()[0])
+        target_representation = set(
+          learnedRepresentations[(objectDescription["name"], iFeature)])
+
+        inferred = (representation <= target_representation)
+        if inferred:
+          break
+
+      self.assertTrue(inferred)

--- a/tests/regions/location_region_test.py
+++ b/tests/regions/location_region_test.py
@@ -231,7 +231,7 @@ class Guassian2DLocationRegionTest(unittest.TestCase):
     learnedRepresentations = defaultdict(list)
 
     # Learn Objects
-    location.setParameter("learn", True)
+    location.setParameter("learningMode", True)
 
     for objectDescription in OBJECTS:
       reset = True
@@ -262,7 +262,7 @@ class Guassian2DLocationRegionTest(unittest.TestCase):
           (objectDescription["name"], iFeature)] = representation
 
     # Infer learned objects
-    location.setParameter("learn", False)
+    location.setParameter("learningMode", False)
 
     for objectDescription in OBJECTS:
       reset = True


### PR DESCRIPTION
@subutai Please review.
There are 2 tests for now, one for the region itself (`tests/regions/location_region_test.py`) and one for the `createL4L6aLocationColumn` network, which mimics the `projects/union_path_integration/infer_hand_crafted_objects.py` experiment using the network API.

Currently there is no tests for `createL246aLocationColumn`.
