### PR TITLE
RES-831: Add option to use "torch.optim.lr_scheduler"

### DIFF
--- a/projects/sdr_paper/pytorch_experiments/experiments.cfg
+++ b/projects/sdr_paper/pytorch_experiments/experiments.cfg
@@ -31,6 +31,12 @@ datadir = "data"
 
 optimizer = SGD
 
+; Learning Rate Scheduler. See "torch.optim.lr_scheduler" for valid class names
+lr_scheduler = "StepLR"
+
+; Configure lr_scheduler class constructor using kwargs style dictionary
+lr_scheduler_params = "{'step_size': 1, 'gamma':%(learning_rate_factor)s}"
+
 ; CNN specific parameters
 use_cnn = False
 c1_out_channels = 10

--- a/projects/sdr_paper/pytorch_experiments/experiments_cnn.cfg
+++ b/projects/sdr_paper/pytorch_experiments/experiments_cnn.cfg
@@ -31,6 +31,12 @@ datadir = "data"
 
 optimizer = SGD
 
+; Learning Rate Scheduler. See "torch.optim.lr_scheduler" for valid class names
+lr_scheduler = "StepLR"
+
+; Configure lr_scheduler class constructor using kwargs style dictionary
+lr_scheduler_params = "{'step_size': 1, 'gamma':%(learning_rate_factor)s}"
+
 ; CNN specific parameters
 use_cnn = True
 c1_out_channels = 20


### PR DESCRIPTION
Replaced the code updating the learning rate with torch.optim.lr_scheduler classes.
Use the `lr_scheduler` and `lr_scheduler_params` to configure the class. See  [experiments.cfg](https://github.com/numenta/htmresearch/compare/master...lscheinkman:RES-831?expand=1#diff-ac61be1fe0ccba165f37f5c3fad5f468R34)

