### PR TITLE
RES-805: Add multi-layer support to sparse net

### DIFF
--- a/htmresearch/frameworks/pytorch/mnist_sparse_experiment.py
+++ b/htmresearch/frameworks/pytorch/mnist_sparse_experiment.py
@@ -114,13 +114,21 @@ class MNISTSparseExperiment(PyExperimentSuite):
       datasets.MNIST(self.dataDir, train=False, transform=transform),
       batch_size=params["test_batch_size"], shuffle=True, **kwargs)
 
+    # Parse 'n' and 'k' parameters
+    n = params["n"]
+    k = params["k"]
+    if isinstance(n, basestring):
+      n = map(int, n.split("_"))
+    if isinstance(k, basestring):
+      k = map(int, k.split("_"))
+
     if params["use_cnn"]:
       sp_model = SparseMNISTCNN(
         c1OutChannels=params["c1_out_channels"],
         c1k=params["c1_k"],
         dropout=params["dropout"],
-        n=params["n"],
-        k=params["k"],
+        n=n,
+        k=k,
         boostStrength=params["boost_strength"],
         weightSparsity=params["weight_sparsity"],
         boostStrengthFactor=params["boost_strength_factor"],
@@ -129,8 +137,8 @@ class MNISTSparseExperiment(PyExperimentSuite):
       print("c1OutputLength=", sp_model.cnnSdr1.outputLength)
     else:
       sp_model = SparseLinearNet(
-        n=params["n"],
-        k=params["k"],
+        n=n,
+        k=k,
         boostStrength=params["boost_strength"],
         weightSparsity=params["weight_sparsity"],
         boostStrengthFactor=params["boost_strength_factor"],

--- a/htmresearch/frameworks/pytorch/sparse_mnist_net.py
+++ b/htmresearch/frameworks/pytorch/sparse_mnist_net.py
@@ -21,7 +21,6 @@
 
 from __future__ import print_function
 import torch.nn as nn
-import torch.nn.functional as F
 
 from htmresearch.frameworks.pytorch.duty_cycle_metrics import (
   maxEntropy
@@ -42,58 +41,86 @@ class SparseLinearNet(nn.Module):
                boostStrengthFactor=1.0,
                dropout=0.0):
     """
-    A network with one hidden layer, which is a k-sparse linear layer.
+    A network with one or more hidden layers, which is a k-sparse linear layer.
 
     :param n:
-      Number of units in the hidden layer.
+      Number of units in each hidden layer.
+    :type n: int or list[int]
 
     :param k:
-      Number of ON (non-zero) units per iteration.
+      Number of ON (non-zero) units per iteration in each hidden layer.
+    :type k: int or list[int]
 
     :param inputSize:
       Total dimensionality of input vector. We apply view(-1, inputSize)
       to the data before passing it to LinearSDR.
+    :type inputSize: int
+
+    :param outputSize:
+      Total dimensionality of output vector
+    :type outputSize: int
 
     :param kInferenceFactor:
       During inference (training=False) we increase k by this factor.
+    :type kInferenceFactor: float
 
     :param weightSparsity:
       Pct of weights that are allowed to be non-zero.
+    :type weightSparsity: float
 
     :param boostStrength:
       boost strength (0.0 implies no boosting).
+    :type boostStrength: float
 
     :param boostStrengthFactor:
       boost strength is multiplied by this factor after each epoch.
       A value < 1.0 will decrement it every epoch.
-      
+    :type boostStrengthFactor: float
+
     :param dropout:
       dropout probability used to train the second and subsequent layers.
       A value 0.0 implies no dropout
+    :type dropout: float
     """
     super(SparseLinearNet, self).__init__()
 
+    if type(k) is not list:
+      k = [k]
+    if type(n) is not list:
+      n = [n]
+    assert(len(n) == len(k))
     assert(weightSparsity >= 0)
-    assert(k <= n)
+    for i in range(len(n)):
+      assert(k[i] <= n[i])
 
     self.k = k
     self.kInferenceFactor = kInferenceFactor
     self.n = n
     self.inputSize = inputSize
-    self.outputSize = outputSize
-    self.linearSdr1 = LinearSDR(inputFeatures=inputSize,
-                                n=n,
-                                k=k,
-                                kInferenceFactor=kInferenceFactor,
-                                weightSparsity=weightSparsity,
-                                boostStrength=boostStrength
-                                )
-
     self.weightSparsity = weightSparsity   # Pct of weights that are non-zero
-    self.l2 = nn.Linear(self.n, outputSize)
-    self.dropout = dropout
     self.boostStrengthFactor = boostStrengthFactor
     self.boostStrength = boostStrength
+
+    # Hidden layers
+    inputFeatures = inputSize
+    for i in range(len(n)):
+      self.add_module("linearSdr{}".format(i+1),
+                      LinearSDR(inputFeatures=inputFeatures,
+                                n=n[i],
+                                k=k[i],
+                                kInferenceFactor=kInferenceFactor,
+                                weightSparsity=weightSparsity,
+                                boostStrength=boostStrength))
+      # Add dropout after each hidden layer
+      if dropout > 0.0:
+        self.add_module("dropout", nn.Dropout(dropout))
+
+      # Feed this layer output into next layer input
+      inputFeatures = n[i]
+
+    # Add one fully connected layer after all hidden layers
+    self.add_module("fc", nn.Linear(self.n[-1], outputSize))
+    self.add_module("logSoftmax", nn.LogSoftmax(dim=1))
 
 
   def postEpoch(self):
@@ -102,27 +129,21 @@ class SparseLinearNet(nn.Module):
     """
     if self.training:
       self.boostStrength = self.boostStrength * self.boostStrengthFactor
-      self.linearSdr1.setBoostStrength(self.boostStrength)
-      print("boostStrength is now:", self.boostStrength)
+      for module in self.children():
+        if type(module) == LinearSDR:
+          module.setBoostStrength(self.boostStrength)
 
-      # The optimizer is updating the weights during training after the forward
-      # step. Therefore we need to re-zero the weights after every epoch
-      self.linearSdr1.rezeroWeights()
+          # The optimizer is updating the weights during training after the forward
+          # step. Therefore we need to re-zero the weights after every epoch
+          module.rezeroWeights()
+
+      print("boostStrength is now:", self.boostStrength)
 
 
   def forward(self, x):
-
-    # First hidden layer
     x = x.view(-1, self.inputSize)
-    x = self.linearSdr1(x)
-
-    # Dropout
-    if self.dropout > 0.0:
-      x = F.dropout(x, p=self.dropout, training=self.training)
-
-    # Output layer
-    x = self.l2(x)
-    x = F.log_softmax(x, dim=1)
+    for module in self.children():
+      x = module.forward(x)
 
     return x
 
@@ -133,14 +154,20 @@ class SparseLinearNet(nn.Module):
 
   def maxEntropy(self):
     """
-    Returns the maximum entropy we can expect from level 1
+    Returns the maximum entropy we can expect
     """
-    return maxEntropy(self.n, self.k)
+    return sum([maxEntropy(self.n[i], self.k[i])
+                for i in range(len(self.n))])
 
 
   def entropy(self):
     """
     Returns the current entropy
     """
-    return self.linearSdr1.entropy()
+    entropy = 0
+    for module in self.children():
+      if type(module) == LinearSDR:
+        entropy += module.entropy()
+
+    return entropy
 


### PR DESCRIPTION
Add support for multiple hidden layers to sparse net. Use the following configuration syntax to add multiple layers to the experiment:

```
[experimentQuick]
n = "150_50"
k = "50_10"
```

For single layer just use integer as before
